### PR TITLE
add YOLOv5-Lite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,6 @@
 [submodule "yolo/ultralytics"]
 	path = yolo/ultralytics
 	url = https://github.com/ultralytics/ultralytics
+[submodule "yolo/yolov5lite"]
+	path = yolo/yolov5lite
+	url = https://github.com/ppogg/YOLOv5-Lite

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -85,6 +85,7 @@ function App() {
                         <select id="version" value={config.version} name="version" className="form-select" aria-label="Default select example"
                                 onChange={e => update({version: e.target.value})}>
                           <option value="v5">YoloV5</option>
+                          <option value="v5lite">YOLOv5-Lite</option>
                           <option value="v6">YoloV6</option>
                           <option value="v7">YoloV7 (detection only)</option>
                           <option value="v8">YoloV8 (detection only)</option>

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from sanic.exceptions import ServerError
 import sentry_sdk
 
 from yolo.export_yolov5 import YoloV5Exporter
+from yolo.export_yolov5lite import YoloV5LiteExporter
 from yolo.export_yolov6 import YoloV6Exporter
 
 import os
@@ -73,6 +74,12 @@ async def upload_file(request):
     if version == "v5":
         try:
             exporter = YoloV5Exporter(conv_path, filename, input_shape, conv_id)
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            raise ServerError(message="Error while loading model", status_code=520)
+    elif version == "v5lite":
+        try:
+            exporter = YoloV5LiteExporter(conv_path, filename, input_shape, conv_id)
         except Exception as e:
             sentry_sdk.capture_exception(e)
             raise ServerError(message="Error while loading model", status_code=520)

--- a/yolo/detect_head.py
+++ b/yolo/detect_head.py
@@ -174,3 +174,32 @@ class DetectV8(nn.Module):
             a[-1].bias.data[:] = 1.0  # box
             b[-1].bias.data[:m.nc] = math.log(5 / m.nc / (640 / s) ** 2)  # cls (.01 objects, 80 classes, 640 img)
 
+
+class DetectV5(nn.Module):
+    # YOLOv5 Detect head for detection models
+    dynamic = False  # force grid reconstruction
+    export = True  # export mode
+
+    def __init__(self, old_detect):  # detection layer
+        super().__init__()
+        self.nc = old_detect.nc  # number of classes
+        self.no = old_detect.no  # number of outputs per anchor
+        self.nl = old_detect.nl  # number of detection layers
+        self.na = old_detect.na
+        self.anchors = old_detect.anchors
+        self.grid = old_detect.grid  # [torch.zeros(1)] * self.nl
+        self.anchor_grid = old_detect.anchor_grid  # anchor grid
+
+        self.stride = old_detect.stride
+        if hasattr(old_detect, "inplace"):
+            self.inplace = old_detect.inplace
+
+        self.f = old_detect.f
+        self.i = old_detect.i
+        self.m = old_detect.m
+
+    def forward(self, x):
+        for i in range(self.nl):
+            x[i] = self.m[i](x[i])  # conv
+            x[i] = x[i].sigmoid()
+        return x

--- a/yolo/export_yolov5lite.py
+++ b/yolo/export_yolov5lite.py
@@ -1,0 +1,109 @@
+# coding=utf-8
+import sys
+sys.path.append("./yolo/yolov5lite")
+
+import onnx
+import onnxsim
+import torch
+import torch.nn as nn
+from yolov5lite.models.common import Conv
+from yolov5lite.models.experimental import attempt_load
+from yolov5lite.utils.activations import Hardswish, SiLU
+
+from yolo.detect_head import DetectV5
+from exporter import Exporter
+
+
+DIR_TMP = "./tmp"
+
+
+class YoloV5LiteExporter(Exporter):
+    def __init__(self, conv_path, weights_filename, imgsz, conv_id):
+        super().__init__(conv_path, weights_filename, imgsz, conv_id)
+        self.load_model()
+
+    def load_model(self):
+        # code based on export.py from YoloV5 repository
+        # load the model
+        model = attempt_load(self.weights_path.resolve(), map_location=torch.device('cpu'))  # load FP32 model
+
+        # check num classes and labels
+        assert model.nc == len(model.names), f'Model class count {model.nc} != len(names) {len(model.names)}'
+
+        # check if image size is suitable
+        gs = int(max(model.stride))  # grid size (max stride)
+        if isinstance(self.imgsz, int):
+            self.imgsz = [self.imgsz, self.imgsz]
+        for sz in self.imgsz:
+            if sz % gs != 0:
+                raise ValueError(f"Image size is not a multiple of maximum stride {gs}")
+
+        # ensure correct length
+        if len(self.imgsz) != 2:
+            raise ValueError(f"Image size must be of length 1 or 2.")
+
+        model.eval()
+        for k, m in model.named_modules():
+            if isinstance(m, Conv):  # assign export-friendly activations
+                m._non_persistent_buffers_set = set()  # torch 1.6.0 compatibility
+                if isinstance(m.act, nn.Hardswish):
+                    m.act = Hardswish()
+                if isinstance(m.act, nn.SiLU):
+                    m.act = SiLU()
+            elif isinstance(m, nn.Upsample):
+                m.recompute_scale_factor = None  # torch 1.11.0 compatibility
+
+        model.model[-1] = DetectV5(model.model[-1])
+
+        self.model = model
+
+        m = model.model[-1]
+        self.num_branches = len(m.anchor_grid)
+
+    def get_onnx(self):
+        # export onnx model
+        self.f_onnx = (self.conv_path / f"{self.model_name}.onnx").resolve()
+        im = torch.zeros(1, 3, *self.imgsz[::-1])#.to(device)  # image size(1,3,320,192) BCHW iDetection
+        torch.onnx.export(self.model, im, self.f_onnx, verbose=False, opset_version=12,
+                        training=torch.onnx.TrainingMode.EVAL,
+                        do_constant_folding=True,
+                        input_names=['images'],
+                        output_names=['output1_yolov5', 'output2_yolov5', 'output3_yolov5'],
+                        dynamic_axes=None)
+
+        # check if the arhcitecture is correct
+        model_onnx = onnx.load(self.f_onnx)  # load onnx model
+        onnx.checker.check_model(model_onnx)  # check onnx model
+        # simplify the moodel
+        return onnxsim.simplify(model_onnx)
+
+    def export_onnx(self):
+        onnx_model, check = self.get_onnx()
+        assert check, "assert check failed"
+
+        # save the simplified model
+        self.f_simplified = (self.conv_path / f"{self.model_name}-simplified.onnx").resolve()
+        onnx.save(onnx_model, self.f_simplified)
+        return self.f_simplified
+
+    def export_openvino(self, version):
+        return super().export_openvino('v5')
+
+    def export_json(self):
+        # generate anchors and sides
+        anchors, sides = [], []
+        m = self.model.module.model[-1] if hasattr(self.model, 'module') else self.model.model[-1]
+        for i in range(self.num_branches):
+            sides.append(int(self.imgsz[0] // m.stride[i]))
+            for j in range(m.anchor_grid[i].size()[1]):
+                anchors.extend(m.anchor_grid[i][0, j, 0, 0].numpy())
+        anchors = [float(x) for x in anchors]
+        # sides.sort()
+
+        # generate masks
+        masks = dict()
+        # for i, num in enumerate(sides[::-1]):
+        for i, num in enumerate(sides):
+            masks[f"side{num}"] = list(range(i * 3, i * 3 + 3))
+
+        return self.write_json(anchors, masks)


### PR DESCRIPTION
Add support for YOLOv5-Lite: lighter, faster and easier to deploy. Evolved from yolov5 and the size of model is only 930+kb (int8) and 1.7M (fp16). It can reach 10+ FPS on the Raspberry Pi 4B when the input size is 320×320~