### PR TITLE
Update detect heads - support for fuse_ab training argument & update Sentry logging

### DIFF
--- a/yolo/detect_head.py
+++ b/yolo/detect_head.py
@@ -38,8 +38,14 @@ class DetectV6R4s(nn.Module):
         self.stems = old_detect.stems
         self.cls_convs = old_detect.cls_convs
         self.reg_convs = old_detect.reg_convs
-        self.cls_preds = old_detect.cls_preds
-        self.reg_preds = old_detect.reg_preds
+        if hasattr(old_detect, 'cls_preds'):
+          self.cls_preds = old_detect.cls_preds
+        elif hasattr(old_detect, 'cls_preds_af'):
+          self.cls_preds = old_detect.cls_preds_af
+        if hasattr(old_detect, 'reg_preds'):
+          self.reg_preds = old_detect.reg_preds
+        elif hasattr(old_detect, 'reg_preds_af'):
+          self.reg_preds = old_detect.reg_preds_af
 
         self.use_rvc2 = use_rvc2
 
@@ -96,8 +102,14 @@ class DetectV6R4m(nn.Module):
         self.stems = old_detect.stems
         self.cls_convs = old_detect.cls_convs
         self.reg_convs = old_detect.reg_convs
-        self.cls_preds = old_detect.cls_preds
-        self.reg_preds = old_detect.reg_preds
+        if hasattr(old_detect, 'cls_preds'):
+          self.cls_preds = old_detect.cls_preds
+        elif hasattr(old_detect, 'cls_preds_af'):
+          self.cls_preds = old_detect.cls_preds_af
+        if hasattr(old_detect, 'reg_preds'):
+          self.reg_preds = old_detect.reg_preds
+        elif hasattr(old_detect, 'reg_preds_af'):
+          self.reg_preds = old_detect.reg_preds_af
 
         self.use_rvc2 = use_rvc2
 

--- a/yolov6r1/main.py
+++ b/yolov6r1/main.py
@@ -133,6 +133,13 @@ async def cleanup(request, response):
 
 if __name__ == '__main__':
     runtime = os.getenv("RUNTIME", "debug")
+    SENTRY_TOKEN = os.getenv("SENTRY_TOKEN")
+    logger.info(f"SENTRY_TOKEN: {SENTRY_TOKEN}")
+    if SENTRY_TOKEN is not None:
+        sentry_sdk.init(
+            dsn=SENTRY_TOKEN
+        )
+    
     if runtime == "prod":
         app.run(host="0.0.0.0", port=8002, access_log=False, workers=8)
     else:

--- a/yolov6r3/main.py
+++ b/yolov6r3/main.py
@@ -144,6 +144,13 @@ async def cleanup(request, response):
 
 if __name__ == '__main__':
     runtime = os.getenv("RUNTIME", "debug")
+    SENTRY_TOKEN = os.getenv("SENTRY_TOKEN")
+    logger.info(f"SENTRY_TOKEN: {SENTRY_TOKEN}")
+    if SENTRY_TOKEN is not None:
+        sentry_sdk.init(
+            dsn=SENTRY_TOKEN
+        )
+    
     if runtime == "prod":
         app.run(host="0.0.0.0", port=8003, access_log=False, workers=8)
     else:

--- a/yolov6r3/yolo/detect_head.py
+++ b/yolov6r3/yolo/detect_head.py
@@ -33,8 +33,14 @@ class DetectV6R3(nn.Module):
         self.stems = old_detect.stems
         self.cls_convs = old_detect.cls_convs
         self.reg_convs = old_detect.reg_convs
-        self.cls_preds = old_detect.cls_preds
-        self.reg_preds = old_detect.reg_preds
+        if hasattr(old_detect, 'cls_preds'):
+          self.cls_preds = old_detect.cls_preds
+        elif hasattr(old_detect, 'cls_preds_af'):
+          self.cls_preds = old_detect.cls_preds_af
+        if hasattr(old_detect, 'reg_preds'):
+          self.reg_preds = old_detect.reg_preds
+        elif hasattr(old_detect, 'reg_preds_af'):
+          self.reg_preds = old_detect.reg_preds_af
 
         self.use_rvc2 = use_rvc2
 


### PR DESCRIPTION
This PR includes:
- YoloV6 R3 & R4 detect head update: supporting of fuse_ab training argument in the detection head 
- Adding Sentry logging for YoloV6 R1 & R3