### PR TITLE
Change the output names list of YOLOv6 export to be dynamic

### DIFF
--- a/yolo/export_yolov6.py
+++ b/yolo/export_yolov6.py
@@ -62,7 +62,7 @@ class YoloV6R4Exporter(Exporter):
                         training=torch.onnx.TrainingMode.EVAL,
                         do_constant_folding=True,
                         input_names=['images'],
-                        output_names=['output1_yolov6r2', 'output2_yolov6r2', 'output3_yolov6r2'],
+                        output_names=[f"output{i+1}_yolov6r2" for i in range(self.num_branches)],
                         dynamic_axes=None)
 
         # check if the arhcitecture is correct

--- a/yolov6r3/yolo/export_gold_yolo.py
+++ b/yolov6r3/yolo/export_gold_yolo.py
@@ -52,7 +52,7 @@ class GoldYoloExporter(Exporter):
                         training=torch.onnx.TrainingMode.EVAL,
                         do_constant_folding=True,
                         input_names=['images'],
-                        output_names=['output1_yolov6r2', 'output2_yolov6r2', 'output3_yolov6r2'],
+                        output_names=[f"output{i+1}_yolov6r2" for i in range(self.num_branches)],
                         dynamic_axes=None)
 
         # check if the arhcitecture is correct

--- a/yolov6r3/yolo/export_yolov6_r3.py
+++ b/yolov6r3/yolo/export_yolov6_r3.py
@@ -67,7 +67,7 @@ class YoloV6R3Exporter(Exporter):
                         training=torch.onnx.TrainingMode.EVAL,
                         do_constant_folding=True,
                         input_names=['images'],
-                        output_names=['output1_yolov6r2', 'output2_yolov6r2', 'output3_yolov6r2'],
+                        output_names=[f"output{i+1}_yolov6r2" for i in range(self.num_branches)],
                         dynamic_axes=None)
 
         # check if the arhcitecture is correct


### PR DESCRIPTION
This PR fixes an issue with YOLOv6 exports with more than 3 branches. The issue is described [here](https://discuss.luxonis.com/d/2307-creating-a-blob-for-oak-ffc-6p-rcv3/14).