### PR TITLE
Add anchors to V5 & V7 export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools"
-version = "0.2.0"
+version = "0.2.1"
 description = "Converter for YOLO models into .ONNX format."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torchvision>=0.10.1
 Pillow>=7.1.2
 PyYAML>=5.3.1
 gcsfs
-luxonis-ml[data,nn_archive]>=0.4.1
+luxonis-ml[data,nn_archive]>=0.5.1
 # luxonis-ml[data,nn_archive] @ git+https://github.com/luxonis/luxonis-ml@dev
 onnx>=1.10.1
 onnxruntime

--- a/tools/modules/exporter.py
+++ b/tools/modules/exporter.py
@@ -162,7 +162,6 @@ class Exporter:
                             "preprocessing": {
                                 "mean": [0, 0, 0],
                                 "scale": [255, 255, 255],
-                                "reverse_channels": True,
                             },
                         }
                     ],

--- a/tools/modules/exporter.py
+++ b/tools/modules/exporter.py
@@ -47,6 +47,7 @@ class Exporter:
         self.model_path = model_path
         self.imgsz = imgsz
         self.model_name = os.path.basename(self.model_path).split(".")[0]
+        self.model = None
         # Set up file paths
         self.f_onnx = None
         self.f_nn_archive = None
@@ -113,6 +114,7 @@ class Exporter:
         n_prototypes: Optional[int] = None,
         n_keypoints: Optional[int] = None,
         is_softmax: Optional[bool] = None,
+        anchors: Optional[List[List[List[float]]]] = None,
         output_kwargs: Optional[dict] = None,
     ):
         """Export the model to NN archive format.
@@ -129,6 +131,7 @@ class Exporter:
             n_prototypes (Optional[int], optional): Number of prototypes. Defaults to None.
             n_keypoints (Optional[int], optional): Number of keypoints. Defaults to None.
             is_softmax (Optional[bool], optional): Whether to use softmax. Defaults to None.
+            anchors (Optional[List[List[List[float]]]], optional): Anchors. Defaults to None.
             output_kwargs (Optional[dict], optional): Output keyword arguments. Defaults to None.
         """
         self.f_nn_archive = (self.output_folder / f"{self.model_name}.tar.xz").resolve()
@@ -185,6 +188,7 @@ class Exporter:
                                 n_prototypes=n_prototypes,
                                 n_keypoints=n_keypoints,
                                 is_softmax=is_softmax,
+                                anchors=anchors,
                                 **output_kwargs,
                             ),
                             outputs=self.all_output_names,

--- a/tools/yolo/yolov5_exporter.py
+++ b/tools/yolo/yolov5_exporter.py
@@ -80,8 +80,8 @@ class YoloV5Exporter(Exporter):
         except Exception as e:
             print(f"Error while getting number of channels: {e}")
 
-        m = model.module.model[-1] if hasattr(model, "module") else model.model[-1]
-        self.num_branches = len(m.anchor_grid)
+        self.m = model.module.model[-1] if hasattr(model, "module") else model.model[-1]
+        self.num_branches = len(self.m.anchor_grid)
 
     def export_nn_archive(self, class_names: Optional[List[str]] = None):
         """
@@ -98,4 +98,10 @@ class YoloV5Exporter(Exporter):
             ), f"Number of the given class names {len(class_names)} does not match number of classes {self.model.nc} provided in the model!"
             names = class_names
 
-        self.make_nn_archive(names, self.model.nc)
+        anchors = [
+            self.m.anchor_grid[i][0, :, 0, 0].numpy().tolist()
+            for i in range(self.num_branches)
+        ]
+        self.make_nn_archive(
+            names, self.model.nc, parser="YOLOExtendedParser", anchors=anchors
+        )

--- a/tools/yolo/yolov8_exporter.py
+++ b/tools/yolo/yolov8_exporter.py
@@ -235,7 +235,6 @@ class YoloV8Exporter(Exporter):
                             "preprocessing": {
                                 "mean": [0, 0, 0],
                                 "scale": [255, 255, 255],
-                                "reverse_channels": True,
                             },
                         }
                     ],
@@ -248,7 +247,7 @@ class YoloV8Exporter(Exporter):
                     ],
                     "heads": [
                         Head(
-                            parser="Classification",
+                            parser="ClassificationParser",
                             metadata=HeadClassificationMetadata(
                                 is_softmax=False,
                                 n_classes=n_classes,

--- a/tools/yolo/yolov8_exporter.py
+++ b/tools/yolo/yolov8_exporter.py
@@ -47,7 +47,7 @@ def get_output_names(mode: int) -> List[str]:
         List[str]: List of output names
     """
     if mode == DETECT_MODE:
-        return ["output1_yolov8", "output2_yolov8", "output3_yolov8"]
+        return ["output1_yolov6r2", "output2_yolov6r2", "output3_yolov6r2"]
     elif mode == SEGMENT_MODE:
         return [
             "output1_yolov8",

--- a/tools/yolov7/yolov7_exporter.py
+++ b/tools/yolov7/yolov7_exporter.py
@@ -64,8 +64,8 @@ class YoloV7Exporter(Exporter):
 
         self.model = model
 
-        m = model.module.model[-1] if hasattr(model, "module") else model.model[-1]
-        self.num_branches = len(m.anchor_grid)
+        self.m = model.module.model[-1] if hasattr(model, "module") else model.model[-1]
+        self.num_branches = len(self.m.anchor_grid)
 
     def export_nn_archive(self, class_names: Optional[List[str]] = None):
         """
@@ -82,4 +82,7 @@ class YoloV7Exporter(Exporter):
             ), f"Number of the given class names {len(class_names)} does not match number of classes {self.model.nc} provided in the model!"
             names = class_names
 
-        self.make_nn_archive(names, self.model.nc)
+        anchors = self.m.anchor_grid[:, 0, :, 0, 0].numpy().tolist()
+        self.make_nn_archive(
+            names, self.model.nc, parser="YOLOExtendedParser", anchors=anchors
+        )


### PR DESCRIPTION
This PR includes:

- addition of anchors to YOLOv5 & v7 export, so that the exported models work with DAI
- bumped version of `luxonis-ml` to `0.5.1`