### PR TITLE
Fix torch dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.9.1
+torch>=1.9.1,<2.6.0
 torchvision>=0.10.1
 Pillow>=7.1.2
 PyYAML>=5.3.1


### PR DESCRIPTION
This PR fixes an issue with the latest torch 2.6.0, with which YOLOv6 and v7 models can't be loaded.
