### PR TITLE
Fix/yolov8 output names nn archive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ gcsfs
 luxonis-ml[data,nn_archive,utils]>=0.6.1
 onnx>=1.17.0
 numpy>=1.19.5,<1.27.0
-scipy==1.10.1
 onnxruntime>=1.20.1
 onnxsim>=0.4.36
 s3fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ gcsfs
 luxonis-ml[data,nn_archive,utils]>=0.6.1
 onnx>=1.17.0
 numpy>=1.19.5,<1.27.0
+scipy==1.10.1
 onnxruntime>=1.20.1
 onnxsim>=0.4.36
 s3fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ PyYAML>=5.3.1
 gcsfs
 luxonis-ml[data,nn_archive,utils]>=0.6.1
 onnx>=1.17.0
+numpy>=1.19.5,<1.27.0
 onnxruntime>=1.20.1
 onnxsim>=0.4.36
 s3fs

--- a/tools/yolo/yolov8_exporter.py
+++ b/tools/yolo/yolov8_exporter.py
@@ -89,7 +89,7 @@ class YoloV8Exporter(Exporter):
             imgsz,
             use_rvc2,
             subtype="yolov8",
-            output_names=["output1_yolov8", "output2_yolov8", "output3_yolov8"],
+            output_names=["output1_yolov6r2", "output2_yolov6r2", "output3_yolov6r2"],
         )
         self.load_model()
 


### PR DESCRIPTION
## Purpose
Fixing the YOLO output names in the NN Archive for YOLOv8 export to match the names of model's outputs.

## Specification
- Fixing the YOLO output names in the NN Archive
- Specifying numpy version in requirements, so that YOLOv5&7 conversion works.

## Dependencies & Potential Impact
- Specifying `numpy>=1.19.5,<1.27.0`

## Deployment Plan
1/ Build Docker image
2/ Push to GHCR
3/ Build tools-cli-plugin && make PR in mlcloud-images
4/ Test on DEV/STG
5/ Push to prod

## Testing & Validation
- Tested locally export of all supported YOLOs to ONNX