### PR TITLE
Bump luxonis-ml version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ build-backend = "setuptools.build_meta"
 where = ["."]
 
 [tool.setuptools.package-data]
-[tool.setuptools.package-data]
 tools = [
     "docker-compose.yaml", 
     "docker-compose-dev.yaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,14 @@ build-backend = "setuptools.build_meta"
 where = ["."]
 
 [tool.setuptools.package-data]
-tools = ["docker-compose.yaml", "docker-compose-dev.yaml"]
+[tool.setuptools.package-data]
+tools = [
+    "docker-compose.yaml", 
+    "docker-compose-dev.yaml",
+    "yolo/ultralytics/ultralytics/cfg/*.yaml",
+    "yolo/yolov5/models/*.yaml",
+    "yolov7/yolov7/cfg/**/*.yaml"
+]
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torchvision>=0.10.1
 Pillow>=7.1.2
 PyYAML>=5.3.1
 gcsfs
-luxonis-ml[data,nn_archive,utils]>=0.6.1
+luxonis-ml[data,nn_archive,utils]==0.6.4
 onnx>=1.17.0
 numpy>=1.19.5,<1.27.0
 onnxruntime>=1.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ torchvision>=0.10.1
 Pillow>=7.1.2
 PyYAML>=5.3.1
 gcsfs
-luxonis-ml[data,nn_archive,utils]==0.6.4
+luxonis-ml[data,nn_archive,utils]>=0.6.4,<0.7
 onnx>=1.17.0
 numpy>=1.19.5,<1.27.0
 onnxruntime>=1.20.1


### PR DESCRIPTION
## Purpose
Bump luxonis-ml to v0.6.4 & fixing YOLOv8 conversion when running inside Docker container.

## Specification
- Updating version of luxonis-ml 
- Adding config files to package data to fix YOLOv8 export inside Docker container.

## Dependencies & Potential Impact
- `luxonis-ml -> v0.6.4`

## Deployment Plan
1/ Build Docker image
2/ Push to GHCR
3/ Build tools-cli-plugin && make PR in mlcloud-images
4/ Test on DEV/STG
5/ Push to prod

## Testing & Validation
- Tested locally export of all supported YOLOs to ONNX both using python package and inside Docker image