### PR TITLE
Support Tools 2.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools"
-version = "0.2.4"
+version = "0.2.5"
 description = "Converter for YOLO models into .ONNX format."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-torch>=2.0.0,<2.6.0
+torch>=2.0.0 #,<2.6.0
 torchvision>=0.10.1
 Pillow>=7.1.2
 PyYAML>=5.3.1
 gcsfs
-luxonis-ml[data,nn_archive,utils]>=0.6.4,<0.7
+luxonis-ml[data,nn_archive,utils]>=0.6.5,<0.7
 onnx>=1.17.0
 numpy>=1.19.5,<2.1.0
 onnxruntime>=1.20.1

--- a/tools/yolo/yolov5_exporter.py
+++ b/tools/yolo/yolov5_exporter.py
@@ -4,6 +4,7 @@ import os
 import sys
 from typing import List, Optional, Tuple
 
+import torch
 import torch.nn as nn
 from loguru import logger
 
@@ -15,9 +16,53 @@ yolov5_path = os.path.join(current_dir, "yolov5")
 sys.path.append(yolov5_path)
 
 from models.common import Conv  # noqa: E402
-from models.experimental import attempt_load as attempt_load_yolov5  # noqa: E402
+import models.experimental  # noqa: E402
 from models.yolo import Detect as DetectYOLOv5  # noqa: E402
 from utils.activations import SiLU  # noqa: E402
+
+
+def attempt_load_yolov5(weights, device=None, inplace=True, fuse=True):
+    # Loads an ensemble of models weights=[a,b,c] or a single model weights=[a] or weights=a
+    from models.yolo import Detect, Model  # noqa: E402
+
+    model = models.experimental.Ensemble()
+    for w in weights if isinstance(weights, list) else [weights]:
+        ckpt = torch.load(models.experimental.attempt_download(w), map_location='cpu', weights_only=False)  # load
+        ckpt = (ckpt.get('ema') or ckpt['model']).to(device).float()  # FP32 model
+
+        # Model compatibility updates
+        if not hasattr(ckpt, 'stride'):
+            ckpt.stride = torch.tensor([32.])
+        if hasattr(ckpt, 'names') and isinstance(ckpt.names, (list, tuple)):
+            ckpt.names = dict(enumerate(ckpt.names))  # convert to dict
+
+        model.append(ckpt.fuse().eval() if fuse and hasattr(ckpt, 'fuse') else ckpt.eval())  # model in eval mode
+
+    # Module compatibility updates
+    for m in model.modules():
+        t = type(m)
+        if t in (nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, Detect, Model):
+            m.inplace = inplace  # torch 1.7.0 compatibility
+            if t is Detect and not isinstance(m.anchor_grid, list):
+                delattr(m, 'anchor_grid')
+                setattr(m, 'anchor_grid', [torch.zeros(1)] * m.nl)
+        elif t is nn.Upsample and not hasattr(m, 'recompute_scale_factor'):
+            m.recompute_scale_factor = None  # torch 1.11.0 compatibility
+
+    # Return model
+    if len(model) == 1:
+        return model[-1]
+
+    # Return detection ensemble
+    print(f'Ensemble created with {weights}\n')
+    for k in 'names', 'nc', 'yaml':
+        setattr(model, k, getattr(model[0], k))
+    model.stride = model[torch.argmax(torch.tensor([m.stride.max() for m in model])).int()].stride  # max stride
+    assert all(model[0].nc == m.nc for m in model), f'Models have different class counts: {[m.nc for m in model]}'
+    return model
+
+# Replace the original function
+models.experimental.attempt_load = attempt_load_yolov5
 
 
 class YoloV5Exporter(Exporter):

--- a/tools/yolo/yolov6_exporter.py
+++ b/tools/yolo/yolov6_exporter.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import os
 import sys
-import torch
 from typing import Tuple
 
+import torch
 from loguru import logger
 
 from tools.modules import DetectV6R4m, DetectV6R4s, Exporter
@@ -14,26 +14,27 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 yolov6_path = os.path.join(current_dir, "YOLOv6")
 sys.path.append(yolov6_path)
 
-from yolov6.layers.common import RepVGGBlock  # noqa: E402
-from yolov6.models.heads.effidehead_distill_ns import Detect  # noqa: E402  
 import yolov6.utils.checkpoint  # noqa: E402
+from yolov6.layers.common import RepVGGBlock  # noqa: E402
+from yolov6.models.heads.effidehead_distill_ns import Detect  # noqa: E402
 
 
 # Override with your custom implementation
 def load_checkpoint(weights, map_location=None, inplace=True, fuse=True):
-  """Load model from checkpoint file."""
-  from yolov6.utils.events import LOGGER  # noqa: E402
-  from yolov6.utils.torch_utils import fuse_model  # noqa: E402
+    """Load model from checkpoint file."""
+    from yolov6.utils.events import LOGGER  # noqa: E402
+    from yolov6.utils.torch_utils import fuse_model  # noqa: E402
 
-  LOGGER.info("Loading checkpoint from {}".format(weights))
-  ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
-  model = ckpt['ema' if ckpt.get('ema') else 'model'].float()
-  if fuse:
-      LOGGER.info("\nFusing model...")
-      model = fuse_model(model).eval()
-  else:
-      model = model.eval()
-  return model
+    LOGGER.info("Loading checkpoint from {}".format(weights))
+    ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
+    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
+    if fuse:
+        LOGGER.info("\nFusing model...")
+        model = fuse_model(model).eval()
+    else:
+        model = model.eval()
+    return model
+
 
 # Replace the original function
 yolov6.utils.checkpoint.load_checkpoint = load_checkpoint

--- a/tools/yolo/yolov6_exporter.py
+++ b/tools/yolo/yolov6_exporter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import torch
 from typing import Tuple
 
 from loguru import logger
@@ -14,8 +15,28 @@ yolov6_path = os.path.join(current_dir, "YOLOv6")
 sys.path.append(yolov6_path)
 
 from yolov6.layers.common import RepVGGBlock  # noqa: E402
-from yolov6.models.heads.effidehead_distill_ns import Detect  # noqa: E402
-from yolov6.utils.checkpoint import load_checkpoint  # noqa: E402
+from yolov6.models.heads.effidehead_distill_ns import Detect  # noqa: E402  
+import yolov6.utils.checkpoint  # noqa: E402
+
+
+# Override with your custom implementation
+def load_checkpoint(weights, map_location=None, inplace=True, fuse=True):
+  """Load model from checkpoint file."""
+  from yolov6.utils.events import LOGGER  # noqa: E402
+  from yolov6.utils.torch_utils import fuse_model  # noqa: E402
+
+  LOGGER.info("Loading checkpoint from {}".format(weights))
+  ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
+  model = ckpt['ema' if ckpt.get('ema') else 'model'].float()
+  if fuse:
+      LOGGER.info("\nFusing model...")
+      model = fuse_model(model).eval()
+  else:
+      model = model.eval()
+  return model
+
+# Replace the original function
+yolov6.utils.checkpoint.load_checkpoint = load_checkpoint
 
 
 class YoloV6R4Exporter(Exporter):

--- a/tools/yolov6r1/yolov6_r1_exporter.py
+++ b/tools/yolov6r1/yolov6_r1_exporter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import torch
 from typing import Tuple
 
 from loguru import logger
@@ -14,7 +15,27 @@ yolo_path = os.path.join(current_dir, "YOLOv6R1")
 sys.path.append(yolo_path)
 
 from yolov6.layers.common import RepVGGBlock  # noqa: E402
-from yolov6.utils.checkpoint import load_checkpoint  # noqa: E402
+import yolov6.utils.checkpoint  # noqa: E402
+
+
+# Override with your custom implementation
+def load_checkpoint(weights, map_location=None, inplace=True, fuse=True):
+  """Load model from checkpoint file."""
+  from yolov6.utils.events import LOGGER  # noqa: E402
+  from yolov6.utils.torch_utils import fuse_model  # noqa: E402
+
+  LOGGER.info("Loading checkpoint from {}".format(weights))
+  ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
+  model = ckpt['ema' if ckpt.get('ema') else 'model'].float()
+  if fuse:
+      LOGGER.info("\nFusing model...")
+      model = fuse_model(model).eval()
+  else:
+      model = model.eval()
+  return model
+
+# Replace the original function
+yolov6.utils.checkpoint.load_checkpoint = load_checkpoint
 
 
 class YoloV6R1Exporter(Exporter):

--- a/tools/yolov6r1/yolov6_r1_exporter.py
+++ b/tools/yolov6r1/yolov6_r1_exporter.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import os
 import sys
-import torch
 from typing import Tuple
 
+import torch
 from loguru import logger
 
 from tools.modules import DetectV6R1, Exporter
@@ -14,25 +14,26 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 yolo_path = os.path.join(current_dir, "YOLOv6R1")
 sys.path.append(yolo_path)
 
-from yolov6.layers.common import RepVGGBlock  # noqa: E402
 import yolov6.utils.checkpoint  # noqa: E402
+from yolov6.layers.common import RepVGGBlock  # noqa: E402
 
 
 # Override with your custom implementation
 def load_checkpoint(weights, map_location=None, inplace=True, fuse=True):
-  """Load model from checkpoint file."""
-  from yolov6.utils.events import LOGGER  # noqa: E402
-  from yolov6.utils.torch_utils import fuse_model  # noqa: E402
+    """Load model from checkpoint file."""
+    from yolov6.utils.events import LOGGER  # noqa: E402
+    from yolov6.utils.torch_utils import fuse_model  # noqa: E402
 
-  LOGGER.info("Loading checkpoint from {}".format(weights))
-  ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
-  model = ckpt['ema' if ckpt.get('ema') else 'model'].float()
-  if fuse:
-      LOGGER.info("\nFusing model...")
-      model = fuse_model(model).eval()
-  else:
-      model = model.eval()
-  return model
+    LOGGER.info("Loading checkpoint from {}".format(weights))
+    ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
+    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
+    if fuse:
+        LOGGER.info("\nFusing model...")
+        model = fuse_model(model).eval()
+    else:
+        model = model.eval()
+    return model
+
 
 # Replace the original function
 yolov6.utils.checkpoint.load_checkpoint = load_checkpoint

--- a/tools/yolov6r3/gold_yolo_exporter.py
+++ b/tools/yolov6r3/gold_yolo_exporter.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import os
 import sys
-import torch
 from typing import Tuple
 
+import torch
 from loguru import logger
 
 from tools.modules import DetectV6R3, Exporter
@@ -25,19 +25,20 @@ from switch_tool import switch_to_deploy  # noqa: E402
 
 # Override with your custom implementation
 def load_checkpoint_gold_yolo(weights, map_location=None, inplace=True, fuse=True):
-  """Load model from checkpoint file."""
-  from yolov6.utils.events import LOGGER  # noqa: E402
-  from yolov6.utils.torch_utils import fuse_model  # noqa: E402
+    """Load model from checkpoint file."""
+    from yolov6.utils.events import LOGGER  # noqa: E402
+    from yolov6.utils.torch_utils import fuse_model  # noqa: E402
 
-  LOGGER.info("Loading checkpoint from {}".format(weights))
-  ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
-  model = ckpt['ema' if ckpt.get('ema') else 'model'].float()
-  if fuse:
-      LOGGER.info("\nFusing model...")
-      model = fuse_model(model).eval()
-  else:
-      model = model.eval()
-  return model
+    LOGGER.info("Loading checkpoint from {}".format(weights))
+    ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
+    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
+    if fuse:
+        LOGGER.info("\nFusing model...")
+        model = fuse_model(model).eval()
+    else:
+        model = model.eval()
+    return model
+
 
 # Replace the original function
 checkpoint.load_checkpoint = load_checkpoint_gold_yolo

--- a/tools/yolov6r3/yolov6_r3_exporter.py
+++ b/tools/yolov6r3/yolov6_r3_exporter.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import os
 import sys
-import torch
 from typing import Tuple
 
+import torch
 from loguru import logger
 
 from tools.modules import DetectV6R3, Exporter, YoloV6BackBone
@@ -14,8 +14,8 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 yolo_path = os.path.join(current_dir, "YOLOv6R3")
 sys.path.append(yolo_path)  # noqa: E402
 
+import yolov6.utils.checkpoint  # noqa: E402
 from yolov6.layers.common import RepVGGBlock  # noqa: E402
-import yolov6.utils.checkpoint # noqa: E402
 
 try:
     from yolov6.models.efficientrep import (
@@ -32,19 +32,20 @@ except Exception as e:
 
 # Override with your custom implementation
 def load_checkpoint(weights, map_location=None, inplace=True, fuse=True):
-  """Load model from checkpoint file."""
-  from yolov6.utils.events import LOGGER # noqa: E402
-  from yolov6.utils.torch_utils import fuse_model # noqa: E402
+    """Load model from checkpoint file."""
+    from yolov6.utils.events import LOGGER  # noqa: E402
+    from yolov6.utils.torch_utils import fuse_model  # noqa: E402
 
-  LOGGER.info("Loading checkpoint from {}".format(weights))
-  ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
-  model = ckpt['ema' if ckpt.get('ema') else 'model'].float()
-  if fuse:
-      LOGGER.info("\nFusing model...")
-      model = fuse_model(model).eval()
-  else:
-      model = model.eval()
-  return model
+    LOGGER.info("Loading checkpoint from {}".format(weights))
+    ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
+    model = ckpt["ema" if ckpt.get("ema") else "model"].float()
+    if fuse:
+        LOGGER.info("\nFusing model...")
+        model = fuse_model(model).eval()
+    else:
+        model = model.eval()
+    return model
+
 
 # Replace the original function
 yolov6.utils.checkpoint.load_checkpoint = load_checkpoint

--- a/tools/yolov6r3/yolov6_r3_exporter.py
+++ b/tools/yolov6r3/yolov6_r3_exporter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import torch
 from typing import Tuple
 
 from loguru import logger
@@ -14,7 +15,7 @@ yolo_path = os.path.join(current_dir, "YOLOv6R3")
 sys.path.append(yolo_path)  # noqa: E402
 
 from yolov6.layers.common import RepVGGBlock  # noqa: E402
-from yolov6.utils.checkpoint import load_checkpoint  # noqa: E402
+import yolov6.utils.checkpoint # noqa: E402
 
 try:
     from yolov6.models.efficientrep import (
@@ -27,6 +28,26 @@ except Exception as e:
     raise ImportError(
         "Error while importing EfficientRep, CSPBepBackbone, CSPBepBackbone_P6 or EfficientRep6: {e}"
     ) from e
+
+
+# Override with your custom implementation
+def load_checkpoint(weights, map_location=None, inplace=True, fuse=True):
+  """Load model from checkpoint file."""
+  from yolov6.utils.events import LOGGER # noqa: E402
+  from yolov6.utils.torch_utils import fuse_model # noqa: E402
+
+  LOGGER.info("Loading checkpoint from {}".format(weights))
+  ckpt = torch.load(weights, map_location=map_location, weights_only=False)  # load
+  model = ckpt['ema' if ckpt.get('ema') else 'model'].float()
+  if fuse:
+      LOGGER.info("\nFusing model...")
+      model = fuse_model(model).eval()
+  else:
+      model = model.eval()
+  return model
+
+# Replace the original function
+yolov6.utils.checkpoint.load_checkpoint = load_checkpoint
 
 
 class YoloV6R3Exporter(Exporter):

--- a/tools/yolov7/yolov7_exporter.py
+++ b/tools/yolov7/yolov7_exporter.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import sys
+import torch
+import torch.nn as nn
 from typing import List, Optional, Tuple
 
 from loguru import logger
@@ -13,7 +15,38 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 yolo_path = os.path.join(current_dir, "yolov7")
 sys.path.append(yolo_path)
 
-from models.experimental import attempt_load  # noqa: E402
+import models.experimental  # noqa: E402
+
+
+def attempt_load(weights, map_location=None):
+    from models.common import Conv, DWConv  # noqa: E402
+    from utils.google_utils import attempt_download  # noqa: E402
+
+    # Loads an ensemble of models weights=[a,b,c] or a single model weights=[a] or weights=a
+    model = models.experimental.Ensemble()
+    for w in weights if isinstance(weights, list) else [weights]:
+        attempt_download(w)
+        ckpt = torch.load(w, map_location=map_location, weights_only=False)  # load
+        model.append(ckpt['ema' if ckpt.get('ema') else 'model'].float().fuse().eval())  # FP32 model
+    
+    # Compatibility updates
+    for m in model.modules():
+        if type(m) in [nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU]:
+            m.inplace = True  # pytorch 1.7.0 compatibility
+        elif type(m) is nn.Upsample:
+            m.recompute_scale_factor = None  # torch 1.11.0 compatibility
+        elif type(m) is Conv:
+            m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
+    
+    if len(model) == 1:
+        return model[-1]  # return model
+    else:
+        print('Ensemble created with %s\n' % weights)
+        for k in ['names', 'stride']:
+            setattr(model, k, getattr(model[-1], k))
+        return model  # return ensemble
+
+models.experimental.attempt_load = attempt_load
 
 
 class YoloV7Exporter(Exporter):


### PR DESCRIPTION
## Purpose
Adds PyTorch v2.6.0 support

## Specification
- Ensuring compatibility with the latest PyTorch version

## Dependencies & Potential Impact
- `torch>=2.0.0,<2.6.0` => `torch>=2.0.0`

## Deployment Plan
1/ Build Docker image
2/ Push to GHCR
3/ Build tools-cli-plugin && make PR in mlcloud-images
4/ Test on DEV/STG
5/ Push to prod

## Testing & Validation
Tested ONNX conversion locally through python package and inside Docker container.