### PR TITLE
Fix/yolov6 export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sanic>=21.12.2
 # torch==1.10.2
 # torchvision==0.11.3
-torch>=2.2.0
+torch>=2.2.0,<2.6.0
 torchvision>=0.10.1
 
 onnx>=1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 sanic>=21.12.2
 # torch==1.10.2
 # torchvision==0.11.3
-torch>=2.2.0,<2.6.0
+torch>=2.2.0
 torchvision>=0.10.1
 
 onnx>=1.16.0
 onnx-simplifier>=0.3.6
-openvino==2022.3.0
-openvino-dev==2022.3.0
+openvino==2023.0.1
+openvino-dev==2023.0.1
 
 blobconverter>=1.4.2
 opencv-python>=4.1.2

--- a/yolov6r1/requirements.txt
+++ b/yolov6r1/requirements.txt
@@ -1,5 +1,5 @@
 sanic>=21.12.2
-torch>=2.2.0
+torch>=2.2.0,<2.6.0
 
 torchvision>=0.11.3
 

--- a/yolov6r3/requirements.txt
+++ b/yolov6r3/requirements.txt
@@ -1,5 +1,5 @@
 sanic>=21.12.2
-torch>=2.2.0
+torch>=2.2.0,<2.6.0
 
 torchvision>=0.11.3
 

--- a/yolov7/requirements.txt
+++ b/yolov7/requirements.txt
@@ -1,5 +1,5 @@
 sanic>=21.12.2
-torch>=2.2.0
+torch>=2.2.0,<2.6.0
 
 torchvision>=0.11.3
 


### PR DESCRIPTION
## Purpose
Fixing YOLOv6 export

## Specification
- Fixing export of YOLOv6 R4 & YOLOv5 models that were trained using `torch==2.6.0`

## Dependencies & Potential Impact
- Remove `torch` version upper bound
- `openvino-dev` and `openvino` bumped to `2023.0.1`

## Deployment Plan
- Deploy to server
- Test

## Testing & Validation
- Tested locally