### PR TITLE
Replace ServerError with SanicException

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from sanic import Sanic, response
 from sanic.config import Config
 from sanic.log import logger
-from sanic.exceptions import ServerError
+from sanic.exceptions import SanicException
   
 import sentry_sdk
 
@@ -90,40 +90,40 @@ async def upload_file(request):
             exporter = YoloV5Exporter(conv_path, filename, input_shape, conv_id, nShaves, useLegacyFrontend, useRVC2)
         except ValueError as ve:
             sentry_sdk.capture_exception(ve)
-            raise ServerError(message=str(ve), status_code=518)
+            raise SanicException(message=str(ve), status_code=518)
         except Exception as e:
             sentry_sdk.capture_exception(e)
-            raise ServerError(message="Error while loading model", status_code=520)
+            raise SanicException(message="Error while loading model", status_code=520)
     elif version == "v6r4":
         try:
             exporter = YoloV6R4Exporter(conv_path, filename, input_shape, conv_id, nShaves, useLegacyFrontend, useRVC2)
         except ValueError as ve:
             sentry_sdk.capture_exception(ve)
-            raise ServerError(message=str(ve), status_code=518)
+            raise SanicException(message=str(ve), status_code=518)
         except Exception as e:
             sentry_sdk.capture_exception(e)
-            raise ServerError(message="Error while loading model (This may be caused by trying to convert older releases 1.0, 2.0 or 3.0, in which case, try to convert using the 'YoloV6 (R1)' or 'YoloV6 (R2, R3)' option).", status_code=516)
+            raise SanicException(message="Error while loading model (This may be caused by trying to convert older releases 1.0, 2.0 or 3.0, in which case, try to convert using the 'YoloV6 (R1)' or 'YoloV6 (R2, R3)' option).", status_code=516)
     elif version == "v8" or version == "v9" or version == "v11":
         try:
             exporter = YoloV8Exporter(conv_path, filename, input_shape, conv_id, nShaves, useLegacyFrontend, useRVC2)
         except ValueError as ve:
             sentry_sdk.capture_exception(ve)
-            raise ServerError(message=str(ve), status_code=518)
+            raise SanicException(message=str(ve), status_code=518)
         except Exception as e:
             sentry_sdk.capture_exception(e)
             if version == "v8":
-                raise ServerError(message="Error while loading model", status_code=520)
+                raise SanicException(message="Error while loading model", status_code=520)
             else:
-                raise ServerError(message="Error while loading model", status_code=515)
+                raise SanicException(message="Error while loading model", status_code=515)
     elif version == "v10":
         try:
             exporter = YoloV10Exporter(conv_path, filename, input_shape, conv_id, nShaves, useLegacyFrontend, useRVC2)
         except ValueError as ve:
             sentry_sdk.capture_exception(ve)
-            raise ServerError(message=str(ve), status_code=518)
+            raise SanicException(message=str(ve), status_code=518)
         except Exception as e:
             sentry_sdk.capture_exception(e)
-            raise ServerError(message="Error while loading model", status_code=520)
+            raise SanicException(message="Error while loading model", status_code=520)
     else:
         raise ValueError(f"Yolo version {version} is not supported.")
     
@@ -132,36 +132,36 @@ async def upload_file(request):
         exporter.export_onnx()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to onnx", status_code=521)
+        raise SanicException(message="Error while converting to onnx", status_code=521)
 
     conversions[conv_id] = "onnx"
     try:
         exporter.export_openvino(version)
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to openvino", status_code=522)
+        raise SanicException(message="Error while converting to openvino", status_code=522)
 
     conversions[conv_id] = "openvino"
     try:
         exporter.export_blob()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error when exporting to blob, likely due to certain operations being unsupported on RVC3. If interested in further information, please open a GitHub issue.", status_code=526)
-        # raise ServerError(message="Error while converting to blob", status_code=523)
+        raise SanicException(message="Error when exporting to blob, likely due to certain operations being unsupported on RVC3. If interested in further information, please open a GitHub issue.", status_code=526)
+        # raise SanicException(message="Error while converting to blob", status_code=523)
 
     conversions[conv_id] = "blob"
     try:
         exporter.export_json()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while making json", status_code=524)
+        raise SanicException(message="Error while making json", status_code=524)
 
     conversions[conv_id] = "json"
     try:
         zip_file = exporter.make_zip()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while making zip", status_code=525)
+        raise SanicException(message="Error while making zip", status_code=525)
 
     conversions[conv_id] = "zip"
 

--- a/yolov6r1/main.py
+++ b/yolov6r1/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from sanic import Sanic, response
 from sanic.config import Config
 from sanic.log import logger
-from sanic.exceptions import ServerError 
+from sanic.exceptions import SanicException 
 
 from yolo.export_yolov6_r1 import YoloV6R1Exporter
 
@@ -77,10 +77,10 @@ async def upload_file(request):
             exporter = YoloV6R1Exporter(conv_path, filename, input_shape, conv_id, nShaves, useLegacyFrontend, useRVC2)
         except ValueError as ve:
             sentry_sdk.capture_exception(ve)
-            raise ServerError(message=str(ve), status_code=518)
+            raise SanicException(message=str(ve), status_code=518)
         except Exception as e:
             sentry_sdk.capture_exception(e)
-            raise ServerError(message="Error while loading model (This may be caused by trying to convert either the latest release 4.0 that isn't supported yet, or by releases 2.0 or 3.0, in which case, try to convert using the 'YoloV6 (R2, R3)' option).", status_code=517)
+            raise SanicException(message="Error while loading model (This may be caused by trying to convert either the latest release 4.0 that isn't supported yet, or by releases 2.0 or 3.0, in which case, try to convert using the 'YoloV6 (R2, R3)' option).", status_code=517)
     else:
         raise ValueError(f"Yolo version {version} is not supported.")
     
@@ -89,35 +89,35 @@ async def upload_file(request):
         exporter.export_onnx()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to onnx", status_code=521)
+        raise SanicException(message="Error while converting to onnx", status_code=521)
 
     conversions[conv_id] = "onnx"
     try:
         exporter.export_openvino(version)
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to openvino", status_code=522)
+        raise SanicException(message="Error while converting to openvino", status_code=522)
 
     conversions[conv_id] = "openvino"
     try:
         exporter.export_blob()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to blob", status_code=523)
+        raise SanicException(message="Error while converting to blob", status_code=523)
     
     conversions[conv_id] = "blob"
     try:
         exporter.export_json()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while making json", status_code=524)
+        raise SanicException(message="Error while making json", status_code=524)
 
     conversions[conv_id] = "json"
     try:
         zip_file = exporter.make_zip()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while making zip", status_code=525)
+        raise SanicException(message="Error while making zip", status_code=525)
 
     conversions[conv_id] = "zip"
 

--- a/yolov6r3/main.py
+++ b/yolov6r3/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from sanic import Sanic, response
 from sanic.config import Config
 from sanic.log import logger
-from sanic.exceptions import ServerError 
+from sanic.exceptions import SanicException 
 
 from yolo.export_yolov6_r3 import YoloV6R3Exporter
 from yolo.export_gold_yolo import GoldYoloExporter
@@ -79,20 +79,20 @@ async def upload_file(request):
             exporter = YoloV6R3Exporter(conv_path, filename, input_shape, conv_id, nShaves, useLegacyFrontend, useRVC2)
         except ValueError as ve:
             sentry_sdk.capture_exception(ve)
-            raise ServerError(message=str(ve), status_code=518)
+            raise SanicException(message=str(ve), status_code=518)
         except Exception as e:
             sentry_sdk.capture_exception(e)
-            raise ServerError(message="Error while loading model (This may be caused by trying to convert either the latest release 4.0, or by release 1.0, in which case, try to convert using the 'Yolo (latest)' or 'YoloV6 (R1)' option).", status_code=519)
+            raise SanicException(message="Error while loading model (This may be caused by trying to convert either the latest release 4.0, or by release 1.0, in which case, try to convert using the 'Yolo (latest)' or 'YoloV6 (R1)' option).", status_code=519)
     elif version == "goldyolo":
         try:
             exporter = GoldYoloExporter(conv_path, filename, input_shape, conv_id, nShaves, useLegacyFrontend, useRVC2)
         except ValueError as ve:
             sentry_sdk.capture_exception(ve)
-            raise ServerError(message=str(ve), status_code=518)
+            raise SanicException(message=str(ve), status_code=518)
         except Exception as e:
             sentry_sdk.capture_exception(e)
             logger.error(e)
-            raise ServerError(message="Error while loading model", status_code=520)
+            raise SanicException(message="Error while loading model", status_code=520)
     else:
         raise ValueError(f"Yolo version {version} is not supported.")
     
@@ -101,35 +101,35 @@ async def upload_file(request):
         exporter.export_onnx()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to onnx", status_code=521)
+        raise SanicException(message="Error while converting to onnx", status_code=521)
 
     conversions[conv_id] = "onnx"
     try:
         exporter.export_openvino(version)
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to openvino", status_code=522)
+        raise SanicException(message="Error while converting to openvino", status_code=522)
 
     conversions[conv_id] = "openvino"
     try:
         exporter.export_blob()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error when exporting to blob, likely due to certain operations being unsupported on RVC3. If interested in further information, please open a GitHub issue.", status_code=526)
+        raise SanicException(message="Error when exporting to blob, likely due to certain operations being unsupported on RVC3. If interested in further information, please open a GitHub issue.", status_code=526)
 
     conversions[conv_id] = "blob"
     try:
         exporter.export_json()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while making json", status_code=524)
+        raise SanicException(message="Error while making json", status_code=524)
 
     conversions[conv_id] = "json"
     try:
         zip_file = exporter.make_zip()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while making zip", status_code=525)
+        raise SanicException(message="Error while making zip", status_code=525)
 
     conversions[conv_id] = "zip"
 

--- a/yolov7/main.py
+++ b/yolov7/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from sanic import Sanic, response
 from sanic.config import Config
 from sanic.log import logger
-from sanic.exceptions import ServerError 
+from sanic.exceptions import SanicException 
 
 import sentry_sdk
 
@@ -77,10 +77,10 @@ async def upload_file(request):
             exporter = YoloV7Exporter(conv_path, filename, input_shape, conv_id, nShaves, useLegacyFrontend, useRVC2)
         except ValueError as ve:
             sentry_sdk.capture_exception(ve)
-            raise ServerError(message=str(ve), status_code=518)
+            raise SanicException(message=str(ve), status_code=518)
         except Exception as e:
             sentry_sdk.capture_exception(e)
-            raise ServerError(message="Error while loading model", status_code=520)
+            raise SanicException(message="Error while loading model", status_code=520)
     else:
         raise ValueError(f"Yolo version {version} is not supported.")
     
@@ -89,35 +89,35 @@ async def upload_file(request):
         exporter.export_onnx()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to onnx", status_code=521)
+        raise SanicException(message="Error while converting to onnx", status_code=521)
 
     conversions[conv_id] = "onnx"
     try:
         exporter.export_openvino(version)
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to openvino", status_code=522)
+        raise SanicException(message="Error while converting to openvino", status_code=522)
 
     conversions[conv_id] = "openvino"
     try:
         exporter.export_blob()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while converting to blob", status_code=523)
+        raise SanicException(message="Error while converting to blob", status_code=523)
 
     conversions[conv_id] = "blob"
     try:
         exporter.export_json()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while making json", status_code=524)
+        raise SanicException(message="Error while making json", status_code=524)
 
     conversions[conv_id] = "json"
     try:
         zip_file = exporter.make_zip()
     except Exception as e:
         sentry_sdk.capture_exception(e)
-        raise ServerError(message="Error while making zip", status_code=525)
+        raise SanicException(message="Error while making zip", status_code=525)
 
     return await response.file(
         location=zip_file.resolve(),


### PR DESCRIPTION
## Purpose
This PR solves the issue with Sanic Exception creation.

## Specification
Fixing `__init__() got an unexpected keyword argument 'status_code'` as described [here](https://sentry.luxonis.com/organizations/luxonis/issues/4191/events/2229982bb82b4a479cf16abb74624bb9/?project=15&query=&referrer=next-event).

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
- Build docker images
- Push to GHCR
- Deploy on server

## Testing & Validation
Tested locally