### PR TITLE
fix: ghcr image building to include submodules

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -2,8 +2,7 @@ name: Publishing a docker image
 
 on:
   push:
-    branches: ['*']
-  workflow_dispatch:
+    branches: ['main']
 
 env:
   NAME: luxonis/tools_cli

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -3,6 +3,7 @@ name: Publishing a docker image
 on:
   push:
     branches: ['*']
+  workflow_dispatch:
 
 env:
   NAME: luxonis/tools_cli

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -2,7 +2,7 @@ name: Publishing a docker image
 
 on:
   push:
-    branches: ['main']
+    branches: ['*']
 
 env:
   NAME: luxonis/tools_cli
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Get tools-cli version
       id: commit
@@ -32,7 +34,6 @@ jobs:
 
     - name: Publish latest
       run: |
-        git submodule update --init --recursive
         docker build -t $NAME:latest .
         docker tag $NAME:latest ghcr.io/$NAME:latest
         docker push ghcr.io/$NAME:latest


### PR DESCRIPTION
## Purpose
Fixing the submodule initialization when building the `ghcr` image.

## Specification
The `actions/checkout` step without `submodules: recursive` just checks out the main repo so running the `git submodule update ...` finds no submodules. We fix this by adding the `submodules: recursive` option to `actions/checkout` step which also makes the `git submodule update ... call` obsolete.

## Dependencies & Potential Impact
None

## Deployment Plan
None

## Testing & Validation
None