### PR TITLE
Add `workflow_call` support in unittests workflow

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -9,6 +9,17 @@ on:
       - 'tools/**'
       - '.github/workflows/unittests.yaml'
 
+  workflow_call:
+    inputs:
+      ml_ref:
+        description: 'luxonis-ml version (branch/tag/SHA)'
+        required: true
+        type: string
+      tools_ref:
+        description: 'tools version (branch/tag/SHA)'
+        required: true
+        type: string
+
 jobs:
   run_tests:
     strategy:
@@ -20,11 +31,21 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Checkout at tools_ref
+      if: ${{ github.event_name != 'pull_request' }}
+      uses: actions/checkout@v4
+      with:
+        repository: Luxonis/tools
+        ref:        ${{ inputs.tools_ref }}
+        path:       tools
+
     - name: Checkout
+      if: ${{ github.event_name == 'pull_request' }}
       uses: actions/checkout@v4
       with:
         ref: ${{ github.head_ref }}
         submodules: recursive  # Ensures submodules are cloned
+        path: tools
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -33,24 +54,36 @@ jobs:
         cache: pip
 
     - name: Install dependencies
+      working-directory: tools
       run: |
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
 
+    - name: Install specified luxonis-ml
+      env:
+        ML_REF: ${{ inputs.ml_ref }}
+      run: |
+        pip uninstall luxonis-ml -y;
+        pip install "luxonis-ml[data,nn_archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
+
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      working-directory: tools
       run: pytest tests --cov=tools --cov-report xml --junit-xml pytest.xml
 
     - name: Run tests [Windows, macOS]
       if: matrix.os != 'ubuntu-latest' || matrix.version != '3.10'
+      working-directory: tools
       run: pytest tests --junit-xml pytest.xml
 
     - name: Generate coverage badge [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      working-directory: tools
       run: coverage-badge -o media/coverage_badge.svg -f
 
     - name: Generate coverage report [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      working-directory: tools
       uses: orgoro/coverage@v3.1
       with:
         coverageFile: coverage.xml
@@ -58,6 +91,7 @@ jobs:
 
     - name: Commit coverage badge [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      working-directory: tools
       run: |
         git config --global user.name 'GitHub Actions'
         git config --global user.email 'actions@github.com'
@@ -67,12 +101,14 @@ jobs:
         }
     - name: Push changes [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
+      working-directory: tools
       uses: ad-m/github-push-action@master
       with:
         branch: ${{ github.head_ref }}
 
     - name: Upload Test Results
       if: always()
+      working-directory: tools
       uses: actions/upload-artifact@v4
       with:
         name: Test Results [${{ matrix.os }}] (Python ${{ matrix.version }})
@@ -87,7 +123,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: write
-    if: always()
+    if: always() && github.event_name == 'pull_request'
 
     steps:
       - name: Checkout

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -46,7 +46,6 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
         submodules: recursive  # Ensures submodules are cloned
-        path: tools
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -55,7 +54,7 @@ jobs:
         cache: pip
 
     - name: Install dependencies
-      working-directory: tools
+      working-directory: ${{ github.event_name != 'pull_request' && 'tools' || '' }}
       run: |
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
@@ -74,12 +73,12 @@ jobs:
 
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
-      working-directory: tools
+      working-directory: ${{ github.event_name != 'pull_request' && 'tools' || '' }}
       run: pytest tests --cov=tools --cov-report xml --junit-xml pytest.xml
 
     - name: Run tests [Windows, macOS]
       if: matrix.os != 'ubuntu-latest' || matrix.version != '3.10'
-      working-directory: tools
+      working-directory: ${{ github.event_name != 'pull_request' && 'tools' || '' }}
       run: pytest tests --junit-xml pytest.xml
 
     - name: Generate coverage badge [Ubuntu]

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -62,6 +62,7 @@ jobs:
 
     - name: Install specified luxonis-ml
       shell: bash
+      if: github.event_name != 'pull_request'
       working-directory: tools
       env:
         ML_REF: ${{ inputs.ml_ref }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -62,6 +62,7 @@ jobs:
     - name: Install specified luxonis-ml
       env:
         ML_REF: ${{ inputs.ml_ref }}
+      if: ${{ github.event_name != 'pull_request' }}
       run: |
         pip uninstall luxonis-ml -y;
         pip install "luxonis-ml[data,nn_archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
@@ -77,21 +78,18 @@ jobs:
       run: pytest tests --junit-xml pytest.xml
 
     - name: Generate coverage badge [Ubuntu]
-      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
-      working-directory: tools
+      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && github.event_name == 'pull_request'
       run: coverage-badge -o media/coverage_badge.svg -f
 
     - name: Generate coverage report [Ubuntu]
-      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
-      working-directory: tools
+      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && github.event_name == 'pull_request'
       uses: orgoro/coverage@v3.1
       with:
         coverageFile: coverage.xml
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Commit coverage badge [Ubuntu]
-      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
-      working-directory: tools
+      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && github.event_name == 'pull_request'
       run: |
         git config --global user.name 'GitHub Actions'
         git config --global user.email 'actions@github.com'
@@ -100,15 +98,13 @@ jobs:
           git commit -m "[Automated] Updated coverage badge"
         }
     - name: Push changes [Ubuntu]
-      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
-      working-directory: tools
+      if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && github.event_name == 'pull_request'
       uses: ad-m/github-push-action@master
       with:
         branch: ${{ github.head_ref }}
 
     - name: Upload Test Results
-      if: always()
-      working-directory: tools
+      if: always() && github.event_name == 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: Test Results [${{ matrix.os }}] (Python ${{ matrix.version }})

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Install specified luxonis-ml
       shell: bash
-      if: inputs.tools_ref != ''
+      if: inputs.ml_ref != ''
       working-directory: tools
       env:
         ML_REF: ${{ inputs.ml_ref }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -59,13 +59,13 @@ jobs:
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
 
-    - name: Install specified luxonis-ml
-      env:
-        ML_REF: ${{ inputs.ml_ref }}
-      if: ${{ github.event_name != 'pull_request' }}
-      run: |
-        pip uninstall luxonis-ml -y;
-        pip install "luxonis-ml[data,nn_archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
+    # - name: Install specified luxonis-ml
+    #   env:
+    #     ML_REF: ${{ inputs.ml_ref }}
+    #   if: ${{ github.event_name != 'pull_request' }}
+    #   run: |
+    #     pip uninstall luxonis-ml -y;
+    #     pip install "luxonis-ml[data,nn_archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
 
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -61,12 +61,15 @@ jobs:
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
 
     - name: Install specified luxonis-ml
+      shell: bash
+      working-directory: tools
       env:
         ML_REF: ${{ inputs.ml_ref }}
-      if: ${{ github.event_name != 'pull_request' }}
       run: |
-        pip uninstall luxonis-ml -y;
-        pip install "luxonis-ml[data,nn_archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
+        pip uninstall luxonis-ml -y
+        pip install \
+          "luxonis-ml[data,nn_archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" \
+          --upgrade --force-reinstall
 
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -38,6 +38,7 @@ jobs:
         repository: Luxonis/tools
         ref:        ${{ inputs.tools_ref }}
         path:       tools
+        submodules: recursive # Ensures submodules are cloned
 
     - name: Checkout
       if: ${{ github.event_name == 'pull_request' }}
@@ -59,13 +60,13 @@ jobs:
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
 
-    # - name: Install specified luxonis-ml
-    #   env:
-    #     ML_REF: ${{ inputs.ml_ref }}
-    #   if: ${{ github.event_name != 'pull_request' }}
-    #   run: |
-    #     pip uninstall luxonis-ml -y;
-    #     pip install "luxonis-ml[data,nn_archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
+    - name: Install specified luxonis-ml
+      env:
+        ML_REF: ${{ inputs.ml_ref }}
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        pip uninstall luxonis-ml -y;
+        pip install "luxonis-ml[data,nn_archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" --upgrade --force-reinstall
 
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout at tools_ref
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ inputs.tools_ref != '' }}
       uses: actions/checkout@v4
       with:
         repository: Luxonis/tools
@@ -54,14 +54,14 @@ jobs:
         cache: pip
 
     - name: Install dependencies
-      working-directory: ${{ github.event_name != 'pull_request' && 'tools' || '' }}
+      working-directory: ${{ inputs.tools_ref != '' && 'tools' || '' }}
       run: |
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
 
     - name: Install specified luxonis-ml
       shell: bash
-      if: github.event_name != 'pull_request'
+      if: inputs.tools_ref != ''
       working-directory: tools
       env:
         ML_REF: ${{ inputs.ml_ref }}
@@ -73,12 +73,12 @@ jobs:
 
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
-      working-directory: ${{ github.event_name != 'pull_request' && 'tools' || '' }}
+      working-directory: ${{ inputs.tools_ref != '' && 'tools' || '' }}
       run: pytest tests --cov=tools --cov-report xml --junit-xml pytest.xml
 
     - name: Run tests [Windows, macOS]
       if: matrix.os != 'ubuntu-latest' || matrix.version != '3.10'
-      working-directory: ${{ github.event_name != 'pull_request' && 'tools' || '' }}
+      working-directory: ${{ inputs.tools_ref != '' && 'tools' || '' }}
       run: pytest tests --junit-xml pytest.xml
 
     - name: Generate coverage badge [Ubuntu]


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

**PR Description:**  
- Introduce `workflow_call` with `ml_ref` and `tools_ref` inputs  
- Checkout `tools` at specified ref when invoked externally  
- Install the target `luxonis-ml` version via `ml_ref`  
- Preserve existing behavior for PR-triggered runs  
- Enables BOM tests on external repos to validate integration in `tools`

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable