### PR TITLE
Pin ONNX to 1.21.0 + new installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd tools
 
 ```bash
 # Install the package
-pip install .
+PIP_CONSTRAINT=constraints.txt pip install .
 # Running the package
 tools yolov6nr4.pt --imgsz "416"
 ```

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+setuptools<82

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 gcsfs
 luxonis-ml[data,nn_archive,utils]~=0.8.0
-onnx==1.17.0
+onnx==1.21.0
 numpy>=1.19.5,<2.1.0
 onnxruntime>=1.20.1
 onnxsim>=0.4.36,<0.6


### PR DESCRIPTION
## Purpose
- Pin ONNX to 1.21.0
- #204 limits the version of setuptools in the CI, this is replicated here locally for a fresh local install to work
- Reference to why setuptools needs to be limited <82: [mmcv issue](https://github.com/open-mmlab/mmcv/issues/3325)
- Tested full conversion pipeline (tools -> modelconverter -> run on rvc4) using these changes and a fresh environment installation, as well as a fresh installation of [this branch of modelconverter](https://github.com/luxonis/modelconverter/pull/216):
  - yolov6l
  - yolov5n
  - yolo26n

## Specification

## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
