### PR TITLE
Bump `requests` for vulnerability in 2.32.2 and restore previous relevantnt comments on shapes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ psutil
 seaborn
 mmcv>=1.5.0,<2.0.0
 dill==0.4.0
-requests>=2.32.2
+requests>=2.33.0

--- a/tools/modules/heads.py
+++ b/tools/modules/heads.py
@@ -601,6 +601,8 @@ class DetectV26(nn.Module):
 
     def _get_decode_boxes(self, preds):
         # Emulate ultralytics.nn.modules.head.Detect._get_decode_boxes for end2end export.
+        # preds["boxes"]: (N, 4, A)
+        # preds["feats"]: list of feature maps [(N, C, H_i, W_i), ...]
         shape = preds["feats"][0].shape  # BCHW
         if self.dynamic or self.shape != shape:
             anchor_points, stride_tensor = self._make_anchors(
@@ -610,6 +612,8 @@ class DetectV26(nn.Module):
             self.strides = stride_tensor.transpose(0, 1)
             self.shape = shape
 
+        # anchors: (1, 2, A), strides: (1, A)
+        # returns: decoded boxes (N, 4, A) in xyxy pixel coordinates
         dbox = self.dist2bbox(
             preds["boxes"], self.anchors.unsqueeze(0), xywh=False, dim=1
         )
@@ -820,6 +824,7 @@ class PoseV26(DetectV26):
         y = torch.cat((dbox, conf, cls_scores), 1)  # (bs, 4+1+nc, num_anchors)
         y = y.permute(0, 2, 1)  # (bs, num_anchors, 5+nc)
 
+        # After _get_decode_boxes, self.anchors is (2, A) and self.strides is (1, A).
         # Decode and concatenate keypoints
         kpts_cat = torch.cat(kpts_raw, dim=2)  # (bs, nk, num_anchors)
         kpts_decoded = self._kpts_decode(bs, kpts_cat)  # (bs, nk, num_anchors)
@@ -833,6 +838,7 @@ class PoseV26(DetectV26):
         Emulate ultralytics.nn.modules.head.Pose26.kpts_decode.
 
         Args:
+            bs: Batch size.
             kpts: Raw keypoint predictions (bs, nk, num_anchors)
 
         Returns:


### PR DESCRIPTION
## Purpose
Running on device with the YOLOExtendedParser:

Detection:
<img width="416" height="407" alt="yolo26det" src="https://github.com/user-attachments/assets/7ee1dc2c-3ccd-4ef0-b305-503db971712e" />

Instance segmentation:
<img width="430" height="408" alt="yolo26seg" src="https://github.com/user-attachments/assets/54f9e686-0a07-4c47-800e-f027cf7d3a13" />

Keypoints:
<img width="298" height="344" alt="yolo26pose" src="https://github.com/user-attachments/assets/7e2f537e-d59f-47cb-b0eb-f0d3cc369639" />


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies to maintain compatibility and stability.

* **Documentation**
  * Enhanced internal documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->