### PR TITLE
Improve unit test times with isolated parallel workers

### DIFF
--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -15,16 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run_tests:
-    name: E2E Tests on ${{ matrix.os }} / Python ${{ matrix.version }} / shard ${{ matrix.shard }}
+  ubuntu_full:
+    name: E2E full on ubuntu-latest / Python ${{ matrix.version }} / shard ${{ matrix.shard }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
         version: ['3.10']
         shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
@@ -32,7 +31,7 @@ jobs:
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.sha }}
-        submodules: recursive  # Ensures submodules are cloned
+        submodules: recursive
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -48,8 +47,56 @@ jobs:
         export PIP_CONSTRAINT="$CONSTRAINTS_FILE"
         pip install -e .[dev]
 
-    - name: Run tests
-      run: pytest tests/test_end2end.py --e2e-shard-index ${{ matrix.shard }} --e2e-shard-count 10 --download-weights -s -v
+    - name: Run full public tests
+      run: pytest tests/test_end2end.py --e2e-suite full --e2e-shard-index ${{ matrix.shard }} --e2e-shard-count 10 --download-weights -s -v
+
+    - name: Authenticate to Google Cloud
+      if: matrix.shard == 0 && github.event.pull_request.head.repo.full_name == github.repository
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+        create_credentials_file: true
+        export_environment_variables: true
+
+    - name: Run private model tests
+      if: matrix.shard == 0 && github.event.pull_request.head.repo.full_name == github.repository
+      run: pytest tests/test_end2end.py::test_private_model_conversion --test-private --delete-weights-now -s -v
+
+  cross_platform_representative:
+    name: E2E representative on ${{ matrix.os }} / Python ${{ matrix.version }} / shard ${{ matrix.shard }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macOS-latest]
+        version: ['3.10']
+        shard: [0, 1]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.sha }}
+        submodules: recursive
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.version }}
+        cache: pip
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        CONSTRAINTS_FILE="$GITHUB_WORKSPACE/constraints.txt"
+        echo "setuptools<82" > "$CONSTRAINTS_FILE"
+        export PIP_CONSTRAINT="$CONSTRAINTS_FILE"
+        pip install -e .[dev]
+
+    - name: Run representative public tests
+      run: pytest tests/test_end2end.py --e2e-suite representative --e2e-shard-index ${{ matrix.shard }} --e2e-shard-count 2 --download-weights -s -v
 
     - name: Authenticate to Google Cloud
       if: matrix.shard == 0 && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -16,12 +16,13 @@ concurrency:
 
 jobs:
   run_tests:
-    name: E2E Tests on ${{ matrix.os }} / Python ${{ matrix.version }}
+    name: E2E Tests on ${{ matrix.os }} / Python ${{ matrix.version }} / shard ${{ matrix.shard }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         version: ['3.10']
+        shard: [0, 1, 2]
 
     runs-on: ${{ matrix.os }}
 
@@ -48,9 +49,10 @@ jobs:
         pip install -e .[dev]
 
     - name: Run tests
-      run: pytest tests/test_end2end.py --download-weights --delete-weights-now -s -v
+      run: pytest tests/test_end2end.py --e2e-shard-index ${{ matrix.shard }} --e2e-shard-count 3 --download-weights -s -v
 
     - name: Authenticate to Google Cloud
+      if: matrix.shard == 0 && github.event.pull_request.head.repo.full_name == github.repository
       uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
@@ -58,5 +60,5 @@ jobs:
         export_environment_variables: true
 
     - name: Run private model tests
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: matrix.shard == 0 && github.event.pull_request.head.repo.full_name == github.repository
       run: pytest tests/test_end2end.py::test_private_model_conversion --test-private --delete-weights-now -s -v

--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         version: ['3.10']
-        shard: [0, 1, 2]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     runs-on: ${{ matrix.os }}
 
@@ -49,7 +49,7 @@ jobs:
         pip install -e .[dev]
 
     - name: Run tests
-      run: pytest tests/test_end2end.py --e2e-shard-index ${{ matrix.shard }} --e2e-shard-count 3 --download-weights -s -v
+      run: pytest tests/test_end2end.py --e2e-shard-index ${{ matrix.shard }} --e2e-shard-count 10 --download-weights -s -v
 
     - name: Authenticate to Google Cloud
       if: matrix.shard == 0 && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -80,11 +80,11 @@ jobs:
     - name: Run tests with coverage [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10'
       working-directory: ${{ inputs.tools_ref != '' && 'tools' || '' }}
-      env:
-        COVERAGE_PROCESS_START: .coveragerc
       run: |
+        export COVERAGE_PROCESS_START="$PWD/.coveragerc"
+        export COVERAGE_FILE="$PWD/.coverage"
         coverage erase
-        coverage run -m pytest tests/test_unittests.py --download-weights --delete-weights-now -s -v --junit-xml pytest.xml
+        coverage run -m pytest tests/test_unittests.py -n 2 --dist load --download-weights -s -v --junit-xml pytest.xml
         coverage combine
         coverage xml -o coverage.xml -i # Recent changes to coverage 7.13 make it stricter where it was previously passing https://coverage.readthedocs.io/en/7.13.0/messages.html#error-no-source
 
@@ -92,7 +92,7 @@ jobs:
     - name: Run tests [Windows, macOS]
       if: matrix.os != 'ubuntu-latest' || matrix.version != '3.10'
       working-directory: ${{ inputs.tools_ref != '' && 'tools' || '' }}
-      run: pytest tests/test_unittests.py --download-weights --delete-weights-now -s -v --junit-xml pytest.xml
+      run: pytest tests/test_unittests.py -n 2 --dist load --download-weights -s -v --junit-xml pytest.xml
 
     - name: Generate coverage badge [Ubuntu]
       if: matrix.os == 'ubuntu-latest' && matrix.version == '3.10' && inputs.tools_ref == '' && inputs.ml_ref == ''

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#dfb317" d="M63 0h36v20H63z"/>
+        <path fill="#fe7d37" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
-        <text x="80" y="14">61%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">58%</text>
+        <text x="80" y="14">58%</text>
     </g>
 </svg>

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#e05d44" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">22%</text>
-        <text x="80" y="14">22%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">61%</text>
+        <text x="80" y="14">61%</text>
     </g>
 </svg>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-xdist>=3.6.1
 pytest-subtests
 pre-commit>=4.1.0
 pytest-cov>=4.1.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,7 +18,7 @@ Unit tests download the preset weights from original repositories and check if t
 
 Here is an example of the call to run:
 
-```
+```bash
 pytest tests/test_unittests.py -n 2 --dist load --download-weights --log-cli-level=INFO --log-file=out.log --log-file-level=DEBUG
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,13 +13,13 @@ Unit tests download the preset weights from original repositories and check if t
                     If set then test only that specific yolo version
 --test-case=TEST_CASE
                     If set then test only that specific test case
---delete-weights-now  Clean weights after every test to save space - but longer test time.
+--delete-weights-now  Clean weights after every test to save disk space, at the cost of longer runtime.
 ```
 
 Here is an example of the call to run:
 
 ```
-pytest --download-weights --log-cli-level=INFO --log-file=out.log --log-file-level=DEBUG .
+pytest tests/test_unittests.py -n 2 --dist load --download-weights --log-cli-level=INFO --log-file=out.log --log-file-level=DEBUG
 ```
 
-This will run the full test suite on all the supported models and store the DEBUG logs into the out.log file.
+This will run the full unit test suite on all supported models and store the DEBUG logs in the out.log file.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import logging
+import os
 import shutil
 from pathlib import Path
 
 import pytest
+
+pytest_plugins = ["e2e_shards"]
 
 logger = logging.getLogger()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import logging
-import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -68,21 +68,42 @@ def test_config(pytestconfig):
     }
 
 
+@pytest.fixture(scope="session")
+def test_workspace(tmp_path_factory, request) -> Path:
+    """Create one isolated conversion workspace per pytest worker."""
+    worker_id = getattr(request.config, "workerinput", {}).get("workerid", "master")
+    workspace = tmp_path_factory.mktemp(f"tools-tests-{worker_id}")
+    (workspace / "weights").mkdir(exist_ok=True)
+    return workspace
+
+
+def _artifact_path(request: pytest.FixtureRequest, name: str) -> Path:
+    """Resolve cleanup paths without changing E2E behavior."""
+    if "test_workspace" in request.fixturenames:
+        workspace = request.getfixturevalue("test_workspace")
+        return Path(workspace) / name
+
+    return Path(name)
+
+
 @pytest.fixture(scope="function", autouse=True)
-def cleanup_output_after_tests(test_config):
+def cleanup_output_after_tests(test_config, request):
     yield  # Tests run here
     if test_config["delete_output"]:
-        folder_to_delete = "shared_with_container"
-        if os.path.exists(folder_to_delete):
+        folder_to_delete = _artifact_path(
+            request,
+            "shared_with_container",
+        )
+        if folder_to_delete.exists():
             shutil.rmtree(folder_to_delete)
             logger.info(f"Removed test artifacts from {folder_to_delete}")
 
 
 @pytest.fixture(scope="function", autouse=True)
-def cleanup_weights_after_tests(test_config):
+def cleanup_weights_after_tests(test_config, request):
     yield  # Tests run here
     if test_config["delete_weights_now"]:
-        folder_to_delete = "weights"
-        if os.path.exists(folder_to_delete):
+        folder_to_delete = _artifact_path(request, "weights")
+        if folder_to_delete.exists():
             shutil.rmtree(folder_to_delete)
             logger.info(f"Removed test artifacts from {folder_to_delete}")

--- a/tests/e2e_shards.py
+++ b/tests/e2e_shards.py
@@ -1,16 +1,10 @@
-# Pytest plugin for deterministic E2E test sharding.
-#
-# The default assignment is generated from the timing profile captured during
-# Task 10. The workflow passes both the shard index and shard count explicitly
-# so the CI topology is easy to review.
-#
-# To try another shard count later, regenerate/add another entry in
-# E2E_SHARD_ASSIGNMENTS_BY_COUNT and keep the collection tests green.
+"Pytest plugin for deterministic E2E test sharding."
 
 from __future__ import annotations
 
 import pytest
 
+DEFAULT_E2E_SUITE = "full"
 DEFAULT_E2E_SHARD_COUNT = 3
 
 E2E_SHARD_ASSIGNMENTS_BY_COUNT: dict[int, tuple[frozenset[str], ...]] = {
@@ -274,9 +268,68 @@ E2E_SHARD_ASSIGNMENTS_BY_COUNT: dict[int, tuple[frozenset[str], ...]] = {
     ),
 }
 
+REPRESENTATIVE_E2E_SHARD_ASSIGNMENTS_BY_COUNT: dict[int, tuple[frozenset[str], ...]] = {
+    2: (
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-sem]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr1]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9t]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-pose]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26n]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-11s-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-v8s-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-cls]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-obb]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-pose]",
+                "tests/test_end2end.py::test_cli_conversion[yolov26_nms]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5nu]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov7t]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-cls]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-obb]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-pose]",
+            }
+        ),
+    ),
+}
+
+E2E_SHARD_ASSIGNMENTS_BY_SUITE = {
+    "full": E2E_SHARD_ASSIGNMENTS_BY_COUNT,
+    "representative": (REPRESENTATIVE_E2E_SHARD_ASSIGNMENTS_BY_COUNT),
+}
+
+FULL_PUBLIC_NODEIDS = frozenset().union(*E2E_SHARD_ASSIGNMENTS_BY_COUNT[10])
+REPRESENTATIVE_PUBLIC_NODEIDS = frozenset().union(
+    *REPRESENTATIVE_E2E_SHARD_ASSIGNMENTS_BY_COUNT[2]
+)
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     group = parser.getgroup("e2e-shards")
+    group.addoption(
+        "--e2e-suite",
+        choices=("full", "representative"),
+        default=DEFAULT_E2E_SUITE,
+        help="Public E2E suite to run.",
+    )
     group.addoption(
         "--e2e-shard-index",
         type=int,
@@ -290,40 +343,74 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--e2e-shard-count",
         type=int,
         default=DEFAULT_E2E_SHARD_COUNT,
-        help=(
-            "Total number of public E2E shards. "
-            "Currently supported counts are listed in "
-            "E2E_SHARD_ASSIGNMENTS_BY_COUNT."
-        ),
+        help=("Total number of public E2E shards for the selected suite."),
     )
 
 
-def supported_e2e_shard_counts() -> tuple[int, ...]:
-    return tuple(sorted(E2E_SHARD_ASSIGNMENTS_BY_COUNT))
+def supported_e2e_suites() -> tuple[str, ...]:
+    return tuple(sorted(E2E_SHARD_ASSIGNMENTS_BY_SUITE))
 
 
-def get_e2e_shard_assignment(shard_count: int) -> tuple[frozenset[str], ...]:
+def supported_e2e_shard_counts(
+    suite: str = DEFAULT_E2E_SUITE,
+) -> tuple[int, ...]:
     try:
-        return E2E_SHARD_ASSIGNMENTS_BY_COUNT[shard_count]
+        assignments = E2E_SHARD_ASSIGNMENTS_BY_SUITE[suite]
     except KeyError as exc:
-        supported = ", ".join(str(count) for count in supported_e2e_shard_counts())
+        supported = ", ".join(supported_e2e_suites())
         raise pytest.UsageError(
-            f"No E2E shard assignment exists for count={shard_count}. "
+            f"Unknown E2E suite={suite!r}. Supported suites: {supported}."
+        ) from exc
+
+    return tuple(sorted(assignments))
+
+
+def get_e2e_shard_assignment(
+    shard_count: int,
+    suite: str = DEFAULT_E2E_SUITE,
+) -> tuple[frozenset[str], ...]:
+    try:
+        assignments = E2E_SHARD_ASSIGNMENTS_BY_SUITE[suite]
+    except KeyError as exc:
+        supported = ", ".join(supported_e2e_suites())
+        raise pytest.UsageError(
+            f"Unknown E2E suite={suite!r}. Supported suites: {supported}."
+        ) from exc
+
+    try:
+        return assignments[shard_count]
+    except KeyError as exc:
+        supported = ", ".join(str(count) for count in supported_e2e_shard_counts(suite))
+        raise pytest.UsageError(
+            "No E2E shard assignment exists for "
+            f"suite={suite!r}, count={shard_count}. "
             f"Supported counts: {supported}. "
-            "Regenerate the shard assignment from the timing profile before "
-            "using this count."
+            "Regenerate the shard assignment before "
+            "using this combination."
         ) from exc
 
 
-def get_e2e_shard_items(shard_index: int, shard_count: int) -> frozenset[str]:
-    assignment = get_e2e_shard_assignment(shard_count)
+def get_e2e_shard_items(
+    shard_index: int,
+    shard_count: int,
+    suite: str = DEFAULT_E2E_SUITE,
+) -> frozenset[str]:
+    assignment = get_e2e_shard_assignment(
+        shard_count,
+        suite,
+    )
+
     if shard_index < 0 or shard_index >= shard_count:
         raise pytest.UsageError(
-            f"Invalid E2E shard index {shard_index} for count={shard_count}."
+            f"Invalid E2E shard index {shard_index} "
+            f"for suite={suite!r}, "
+            f"count={shard_count}."
         )
+
     if len(assignment) != shard_count:
         raise pytest.UsageError(
-            f"E2E shard assignment for count={shard_count} has "
+            f"E2E shard assignment for suite={suite!r}, "
+            f"count={shard_count} has "
             f"{len(assignment)} shards."
         )
 
@@ -333,18 +420,41 @@ def get_e2e_shard_items(shard_index: int, shard_count: int) -> frozenset[str]:
 def validate_e2e_shard_assignment(
     public_nodeids: set[str],
     assignment: tuple[frozenset[str], ...],
+    suite: str = DEFAULT_E2E_SUITE,
 ) -> None:
-    manifest_nodeids = set().union(*assignment)
+    missing_from_full = sorted(public_nodeids - FULL_PUBLIC_NODEIDS)
+    stale_in_full = sorted(FULL_PUBLIC_NODEIDS - public_nodeids)
 
-    missing_from_assignment = sorted(public_nodeids - manifest_nodeids)
-    stale_in_assignment = sorted(manifest_nodeids - public_nodeids)
-
-    if missing_from_assignment or stale_in_assignment:
+    if missing_from_full or stale_in_full:
         raise pytest.UsageError(
-            "Public E2E collection changed. Regenerate "
-            "E2E_SHARD_ASSIGNMENTS_BY_COUNT. "
-            f"Missing from assignment: {missing_from_assignment}. "
-            f"Stale in assignment: {stale_in_assignment}."
+            "Public E2E collection changed. "
+            "Regenerate the full shard assignment. "
+            f"Missing from assignment: "
+            f"{missing_from_full}. "
+            f"Stale in assignment: {stale_in_full}."
+        )
+
+    expected_nodeids = {
+        "full": FULL_PUBLIC_NODEIDS,
+        "representative": (REPRESENTATIVE_PUBLIC_NODEIDS),
+    }.get(suite)
+
+    if expected_nodeids is None:
+        supported = ", ".join(supported_e2e_suites())
+        raise pytest.UsageError(
+            f"Unknown E2E suite={suite!r}. Supported suites: {supported}."
+        )
+
+    assignment_nodeids = frozenset().union(*assignment)
+    missing = sorted(expected_nodeids - assignment_nodeids)
+    stale = sorted(assignment_nodeids - expected_nodeids)
+
+    if missing or stale:
+        raise pytest.UsageError(
+            f"E2E assignment changed for "
+            f"suite={suite!r}. "
+            f"Missing from assignment: {missing}. "
+            f"Stale in assignment: {stale}."
         )
 
 
@@ -356,9 +466,17 @@ def pytest_collection_modifyitems(
     if shard_index is None:
         return
 
+    suite = config.getoption("e2e_suite")
     shard_count = config.getoption("e2e_shard_count")
-    selected_nodeids = get_e2e_shard_items(shard_index, shard_count)
-    assignment = get_e2e_shard_assignment(shard_count)
+    selected_nodeids = get_e2e_shard_items(
+        shard_index,
+        shard_count,
+        suite,
+    )
+    assignment = get_e2e_shard_assignment(
+        shard_count,
+        suite,
+    )
 
     public_nodeids = {
         item.nodeid
@@ -370,6 +488,7 @@ def pytest_collection_modifyitems(
     validate_e2e_shard_assignment(
         public_nodeids,
         assignment,
+        suite,
     )
 
     selected_items: list[pytest.Item] = []

--- a/tests/e2e_shards.py
+++ b/tests/e2e_shards.py
@@ -129,6 +129,149 @@ E2E_SHARD_ASSIGNMENTS_BY_COUNT: dict[int, tuple[frozenset[str], ...]] = {
             }
         ),
     ),
+    10: (
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-sem]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-11l-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6lr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6tr1]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9m]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov12n]",
+                "tests/test_end2end.py::test_yolo26_semseg_nnarchive_head",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolov10m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5l6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6mr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-pose]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8s]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov8n-pose]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-pose]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-cls]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5l6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5m6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6mr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr1]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolo26n-pose]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yoloe-v8m-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-v8s-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6lr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9t]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov9t]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5m6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5mu]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5nu]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5s6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5su]",
+                "tests/test_end2end.py::test_cli_conversion[yolov7x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolo26n-seg]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov8n]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26l]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10b]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr1]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9e]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov8n-seg]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yoloe-11s-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5lu]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5s6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov7t]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8x]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26s]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-11m-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-pose]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6lr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6mr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-cls]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov11n-pose]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov11n-seg]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26m]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26n]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-v8l-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov26_nms]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6mr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6tr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-obb]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolo26n]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov11n]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolov10s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-obb]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6lr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov7]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9c]",
+            }
+        ),
+    ),
 }
 
 
@@ -187,6 +330,24 @@ def get_e2e_shard_items(shard_index: int, shard_count: int) -> frozenset[str]:
     return assignment[shard_index]
 
 
+def validate_e2e_shard_assignment(
+    public_nodeids: set[str],
+    assignment: tuple[frozenset[str], ...],
+) -> None:
+    manifest_nodeids = set().union(*assignment)
+
+    missing_from_assignment = sorted(public_nodeids - manifest_nodeids)
+    stale_in_assignment = sorted(manifest_nodeids - public_nodeids)
+
+    if missing_from_assignment or stale_in_assignment:
+        raise pytest.UsageError(
+            "Public E2E collection changed. Regenerate "
+            "E2E_SHARD_ASSIGNMENTS_BY_COUNT. "
+            f"Missing from assignment: {missing_from_assignment}. "
+            f"Stale in assignment: {stale_in_assignment}."
+        )
+
+
 def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
@@ -197,6 +358,19 @@ def pytest_collection_modifyitems(
 
     shard_count = config.getoption("e2e_shard_count")
     selected_nodeids = get_e2e_shard_items(shard_index, shard_count)
+    assignment = get_e2e_shard_assignment(shard_count)
+
+    public_nodeids = {
+        item.nodeid
+        for item in items
+        if item.nodeid.startswith("tests/test_end2end.py::")
+        and "::test_private_model_conversion" not in item.nodeid
+    }
+
+    validate_e2e_shard_assignment(
+        public_nodeids,
+        assignment,
+    )
 
     selected_items: list[pytest.Item] = []
     deselected_items: list[pytest.Item] = []

--- a/tests/e2e_shards.py
+++ b/tests/e2e_shards.py
@@ -1,0 +1,213 @@
+# Pytest plugin for deterministic E2E test sharding.
+#
+# The default assignment is generated from the timing profile captured during
+# Task 10. The workflow passes both the shard index and shard count explicitly
+# so the CI topology is easy to review.
+#
+# To try another shard count later, regenerate/add another entry in
+# E2E_SHARD_ASSIGNMENTS_BY_COUNT and keep the collection tests green.
+
+from __future__ import annotations
+
+import pytest
+
+DEFAULT_E2E_SHARD_COUNT = 3
+
+E2E_SHARD_ASSIGNMENTS_BY_COUNT: dict[int, tuple[frozenset[str], ...]] = {
+    3: (
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26m]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-pose]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26x]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-v8l-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5l6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5lu]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5m6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5mu]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6mr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6mr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr1]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6tr1]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-cls]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-obb]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-pose]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9c]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9e]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolo26n-pose]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolo26n-seg]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov11n]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov8n-pose]",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yolo26l]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26n-sem]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26n]",
+                "tests/test_end2end.py::test_cli_conversion[yolo26s]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-11s-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-v8m-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-v8s-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10b]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov26_nms]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5m6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5nu]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5s6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6lr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6lr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6lr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6mr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov7]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9s]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolo26n]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov11n-seg]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov8n]",
+                "tests/test_end2end.py::test_yolo26_semseg_nnarchive_head",
+            }
+        ),
+        frozenset(
+            {
+                "tests/test_end2end.py::test_cli_conversion[yoloe-11l-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yoloe-11m-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov10x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-cls]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-obb]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11n-pose]",
+                "tests/test_end2end.py::test_cli_conversion[yolov11x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov12n]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5l6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5n6u]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5s6]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5s]",
+                "tests/test_end2end.py::test_cli_conversion[yolov5su]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6lr3]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6mr4]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6nr21]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr1]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6sr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov6tr2]",
+                "tests/test_end2end.py::test_cli_conversion[yolov7t]",
+                "tests/test_end2end.py::test_cli_conversion[yolov7x]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8l]",
+                "tests/test_end2end.py::test_cli_conversion[yolov8n-seg]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9m]",
+                "tests/test_end2end.py::test_cli_conversion[yolov9t]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov11n-pose]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov12n]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov8n-seg]",
+                "tests/test_end2end.py::test_n_variant_nnarchive_outputs[yolov9t]",
+            }
+        ),
+    ),
+}
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("e2e-shards")
+    group.addoption(
+        "--e2e-shard-index",
+        type=int,
+        default=None,
+        help=(
+            "Run only one deterministic public E2E shard. "
+            "Use together with --e2e-shard-count."
+        ),
+    )
+    group.addoption(
+        "--e2e-shard-count",
+        type=int,
+        default=DEFAULT_E2E_SHARD_COUNT,
+        help=(
+            "Total number of public E2E shards. "
+            "Currently supported counts are listed in "
+            "E2E_SHARD_ASSIGNMENTS_BY_COUNT."
+        ),
+    )
+
+
+def supported_e2e_shard_counts() -> tuple[int, ...]:
+    return tuple(sorted(E2E_SHARD_ASSIGNMENTS_BY_COUNT))
+
+
+def get_e2e_shard_assignment(shard_count: int) -> tuple[frozenset[str], ...]:
+    try:
+        return E2E_SHARD_ASSIGNMENTS_BY_COUNT[shard_count]
+    except KeyError as exc:
+        supported = ", ".join(str(count) for count in supported_e2e_shard_counts())
+        raise pytest.UsageError(
+            f"No E2E shard assignment exists for count={shard_count}. "
+            f"Supported counts: {supported}. "
+            "Regenerate the shard assignment from the timing profile before "
+            "using this count."
+        ) from exc
+
+
+def get_e2e_shard_items(shard_index: int, shard_count: int) -> frozenset[str]:
+    assignment = get_e2e_shard_assignment(shard_count)
+    if shard_index < 0 or shard_index >= shard_count:
+        raise pytest.UsageError(
+            f"Invalid E2E shard index {shard_index} for count={shard_count}."
+        )
+    if len(assignment) != shard_count:
+        raise pytest.UsageError(
+            f"E2E shard assignment for count={shard_count} has "
+            f"{len(assignment)} shards."
+        )
+
+    return assignment[shard_index]
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    shard_index = config.getoption("e2e_shard_index")
+    if shard_index is None:
+        return
+
+    shard_count = config.getoption("e2e_shard_count")
+    selected_nodeids = get_e2e_shard_items(shard_index, shard_count)
+
+    selected_items: list[pytest.Item] = []
+    deselected_items: list[pytest.Item] = []
+
+    for item in items:
+        if item.nodeid in selected_nodeids:
+            selected_items.append(item)
+        else:
+            deselected_items.append(item)
+
+    if deselected_items:
+        config.hook.pytest_deselected(items=deselected_items)
+
+    items[:] = selected_items

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -6,6 +6,7 @@ import logging
 import os
 import tarfile
 from pathlib import Path
+from typing import Optional
 
 import requests
 from constants import MODEL_TYPE2URL
@@ -47,9 +48,13 @@ def download_private_model(model_name: str, filename: str, folder: str) -> str:
     return str(final_path)
 
 
-def nn_archive_checker(extra_keys_to_check: list = []):  # noqa: B006
+def nn_archive_checker(
+    extra_keys_to_check: Optional[list] = None,
+    output_dir: str = "shared_with_container/outputs",
+):
     """Tests the content of the exported NNArchive."""
-    output_dir = "shared_with_container/outputs"
+    if extra_keys_to_check is None:
+        extra_keys_to_check = []
     subdirs = [
         d for d in os.listdir(output_dir) if os.path.isdir(os.path.join(output_dir, d))
     ]

--- a/tests/test_unittests.py
+++ b/tests/test_unittests.py
@@ -268,10 +268,77 @@ def test_e2e_shard_count_three_manifest_matches_profile():
     )
 
     assert e2e_shards.DEFAULT_E2E_SHARD_COUNT == 3
-    assert e2e_shards.supported_e2e_shard_counts() == (3,)
+    assert e2e_shards.supported_e2e_shard_counts() == (3, 10)
     assert counts == (33, 35, 33)
     assert len(public_union) == 101
     assert public_overlap == set()
+
+
+def test_e2e_shard_count_ten_manifest_matches_selected_profile():
+    import importlib
+
+    e2e_shards = importlib.import_module("e2e_shards")
+
+    count_three = e2e_shards.get_e2e_shard_assignment(3)
+    assignment = e2e_shards.get_e2e_shard_assignment(10)
+
+    counts = tuple(len(shard) for shard in assignment)
+    public_union = set().union(*assignment)
+    count_three_union = set().union(*count_three)
+
+    seen = set()
+    overlap = set()
+
+    for shard in assignment:
+        overlap.update(seen & shard)
+        seen.update(shard)
+
+    assert len(assignment) == 10
+    assert counts == (11, 9, 9, 11, 11, 10, 9, 11, 11, 9)
+    assert all(assignment)
+    assert len(public_union) == 101
+    assert public_union == count_three_union
+    assert overlap == set()
+
+
+def test_e2e_shard_assignment_detects_collection_drift():
+    import importlib
+
+    import pytest
+
+    e2e_shards = importlib.import_module("e2e_shards")
+    assignment = (
+        frozenset(
+            {
+                "tests/test_end2end.py::test_a",
+                "tests/test_end2end.py::test_b",
+            }
+        ),
+    )
+
+    with pytest.raises(
+        pytest.UsageError,
+        match="Missing from assignment",
+    ):
+        e2e_shards.validate_e2e_shard_assignment(
+            {
+                "tests/test_end2end.py::test_a",
+                "tests/test_end2end.py::test_b",
+                "tests/test_end2end.py::test_new",
+            },
+            assignment,
+        )
+
+    with pytest.raises(
+        pytest.UsageError,
+        match="Stale in assignment",
+    ):
+        e2e_shards.validate_e2e_shard_assignment(
+            {
+                "tests/test_end2end.py::test_a",
+            },
+            assignment,
+        )
 
 
 def test_e2e_shard_count_requires_checked_in_assignment():

--- a/tests/test_unittests.py
+++ b/tests/test_unittests.py
@@ -301,31 +301,43 @@ def test_e2e_shard_count_ten_manifest_matches_selected_profile():
     assert overlap == set()
 
 
+def test_e2e_representative_shard_manifest():
+    import importlib
+
+    e2e_shards = importlib.import_module("e2e_shards")
+
+    assignment = e2e_shards.get_e2e_shard_assignment(
+        2,
+        "representative",
+    )
+    counts = tuple(len(shard) for shard in assignment)
+    representative_nodeids = set().union(*assignment)
+    full_nodeids = set().union(*e2e_shards.get_e2e_shard_assignment(10))
+
+    assert e2e_shards.supported_e2e_suites() == (
+        "full",
+        "representative",
+    )
+    assert e2e_shards.supported_e2e_shard_counts("representative") == (2,)
+    assert counts == (14, 16)
+    assert len(representative_nodeids) == 30
+    assert representative_nodeids < full_nodeids
+    assert assignment[0].isdisjoint(assignment[1])
+
+
 def test_e2e_shard_assignment_detects_collection_drift():
     import importlib
 
-    import pytest
-
     e2e_shards = importlib.import_module("e2e_shards")
-    assignment = (
-        frozenset(
-            {
-                "tests/test_end2end.py::test_a",
-                "tests/test_end2end.py::test_b",
-            }
-        ),
-    )
+    assignment = e2e_shards.get_e2e_shard_assignment(10)
+    public_nodeids = set().union(*assignment)
 
     with pytest.raises(
         pytest.UsageError,
         match="Missing from assignment",
     ):
         e2e_shards.validate_e2e_shard_assignment(
-            {
-                "tests/test_end2end.py::test_a",
-                "tests/test_end2end.py::test_b",
-                "tests/test_end2end.py::test_new",
-            },
+            public_nodeids | {"tests/test_end2end.py::test_new_public_case"},
             assignment,
         )
 
@@ -334,9 +346,7 @@ def test_e2e_shard_assignment_detects_collection_drift():
         match="Stale in assignment",
     ):
         e2e_shards.validate_e2e_shard_assignment(
-            {
-                "tests/test_end2end.py::test_a",
-            },
+            public_nodeids - {next(iter(public_nodeids))},
             assignment,
         )
 

--- a/tests/test_unittests.py
+++ b/tests/test_unittests.py
@@ -1,15 +1,44 @@
 from __future__ import annotations
 
 import logging
-import os
 import subprocess
+from pathlib import Path
 
 import pytest
-from constants import SAVE_FOLDER
 from helper_functions import download_model, nn_archive_checker
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+
+def _prepare_model(model_name: str, test_workspace: Path) -> str:
+    """Return an absolute model path inside the current worker workspace."""
+    weights_dir = test_workspace / "weights"
+    model_path = weights_dir / f"{model_name}.pt"
+
+    if not model_path.exists():
+        download_model(model_name, str(weights_dir))
+
+    return str(model_path.resolve())
+
+
+def _run_tools(
+    command: list[str],
+    test_workspace: Path,
+) -> subprocess.CompletedProcess:
+    """Run one conversion inside the isolated worker workspace."""
+    return subprocess.run(
+        command,
+        cwd=test_workspace,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _output_dir(test_workspace: Path) -> str:
+    return str(test_workspace / "shared_with_container" / "outputs")
+
 
 MODEL_EXPLICIT_VERSION = [
     ("yolov5n", "yolov5"),
@@ -30,22 +59,21 @@ MODEL_EXPLICIT_VERSION = [
     MODEL_EXPLICIT_VERSION,
     ids=[model[0] for model in MODEL_EXPLICIT_VERSION],
 )
-def test_explicit_version(model_info: tuple[str, str]):
+def test_explicit_version(
+    model_info: tuple[str, str],
+    test_workspace: Path,
+):
     """Tests setting explicit version."""
     model_name = model_info[0]
     version = model_info[1]
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     command = ["tools", model_path, "--version", version]
     if version == "yolov5":  # edge case when stride=64 is needed
         command += ["--imgsz", "320"]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     if result.returncode != 0:
         pytest.fail(f"Exit code: {result.returncode}, Output: {result.stdout}")
 
@@ -57,38 +85,37 @@ def test_explicit_version(model_info: tuple[str, str]):
         ("yolov10", 4),
     ],
 )
-def test_wrong_explicit_version(version: str, expected_exit_code: int):
+def test_wrong_explicit_version(
+    version: str,
+    expected_exit_code: int,
+    test_workspace: Path,
+):
     """Tests setting wrong version - either not valid or not compatible"""
     model_name = "yolov8n"
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     command = ["tools", model_path, "--version", version]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     assert result.returncode == expected_exit_code, (
         f"Expected exit code {expected_exit_code}, got {result.returncode}. "
     )
 
 
 @pytest.mark.parametrize("input_size", ["64", "64 64", "128 64"])
-def test_explicit_input_size(input_size: str):
+def test_explicit_input_size(
+    input_size: str,
+    test_workspace: Path,
+):
     """Tests setting explicit input size."""
     model_name = "yolov8n"
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     command = ["tools", model_path, "--imgsz", input_size]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     if result.returncode != 0:
         pytest.fail(f"Exit code: {result.returncode}, Output: {result.stdout}")
 
@@ -100,43 +127,44 @@ def test_explicit_input_size(input_size: str):
     extra_keys_to_check = [
         (["model", "inputs", 0, "shape"], [1, 3, imgsz[1], imgsz[0]])
     ]
-    nn_archive_checker(extra_keys_to_check=extra_keys_to_check)
+    nn_archive_checker(
+        extra_keys_to_check=extra_keys_to_check,
+        output_dir=_output_dir(test_workspace),
+    )
 
 
 @pytest.mark.parametrize("input_size", ["64 a", "a", "a a"])
-def test_wrong_explicit_input_size(input_size: str):
+def test_wrong_explicit_input_size(
+    input_size: str,
+    test_workspace: Path,
+):
     """Tests setting wrong explicit input size."""
     model_name = "yolov8n"
     expected_exit_code = 2
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     command = ["tools", model_path, "--imgsz", input_size]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     assert result.returncode == expected_exit_code, (
         f"Expected to fail for invalid --imgsz `{input_size}`, got exit code: {result.returncode}. "
     )
 
 
 @pytest.mark.parametrize("encoding", ["RGB", "BGR", "rgb", "bgr"])
-def test_explicit_encoding(encoding: str):
+def test_explicit_encoding(
+    encoding: str,
+    test_workspace: Path,
+):
     """Tests setting explicit encoding."""
     model_name = "yolov8n"
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     command = ["tools", model_path, "--encoding", encoding]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     if result.returncode != 0:
         pytest.fail(f"Exit code: {result.returncode}, Output: {result.stdout}")
 
@@ -146,43 +174,41 @@ def test_explicit_encoding(encoding: str):
             "RGB888p" if encoding.lower() == "rgb" else "BGR888p",
         )
     ]
-    nn_archive_checker(extra_keys_to_check=extra_keys_to_check)
+    nn_archive_checker(
+        extra_keys_to_check=extra_keys_to_check,
+        output_dir=_output_dir(test_workspace),
+    )
 
 
 @pytest.mark.parametrize("encoding", ["gray", "a"])
-def test_wrong_explicit_encoding(encoding: str):
+def test_wrong_explicit_encoding(
+    encoding: str,
+    test_workspace: Path,
+):
     """Tests setting wrong explicit encoding."""
     model_name = "yolov8n"
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     command = ["tools", model_path, "--encoding", encoding]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     assert result.returncode != 0, (
         f"Expected to fail for invalid --encoding `{encoding}`, got exit code: {result.returncode}. "
     )
 
 
-def test_explicit_class_names():
+def test_explicit_class_names(test_workspace: Path):
     """Tests setting explicit class_names."""
     model_name = "yolov8n"
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     class_names = ["a"] * 80
     class_names_str = ", ".join(class_names)
     command = ["tools", model_path, "--class-names", class_names_str]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     if result.returncode != 0:
         pytest.fail(f"Exit code: {result.returncode}, Output: {result.stdout}")
 
@@ -192,41 +218,36 @@ def test_explicit_class_names():
             class_names,
         )
     ]
-    nn_archive_checker(extra_keys_to_check=extra_keys_to_check)
+    nn_archive_checker(
+        extra_keys_to_check=extra_keys_to_check,
+        output_dir=_output_dir(test_workspace),
+    )
 
 
-def test_wrong_explicit_class_names():
+def test_wrong_explicit_class_names(test_workspace: Path):
     """Tests setting wrong explicit class names."""
     model_name = "yolov8n"
     expected_exit_code = 6
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     class_names_str = "a"
     command = ["tools", model_path, "--class-names", class_names_str]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     assert result.returncode == expected_exit_code, (
         f"Expected to fail for invalid --class-names `{class_names_str}`, got exit code: {result.returncode}. "
     )
 
 
-def test_explicit_version_detection():
+def test_explicit_version_detection(test_workspace: Path):
     """Tests setting explicit version detection."""
     model_name = "yolov8n"
-    model_path = os.path.join(SAVE_FOLDER, f"{model_name}.pt")
-    if not os.path.exists(model_path):
-        download_model(model_name, SAVE_FOLDER)
+    model_path = _prepare_model(model_name, test_workspace)
 
     command = ["tools", model_path]
     logger.debug(f"CLI command: {command}")
 
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    result = _run_tools(command, test_workspace)
     if result.returncode != 0:
         pytest.fail(f"Exit code: {result.returncode}, Output: {result.stdout}")

--- a/tests/test_unittests.py
+++ b/tests/test_unittests.py
@@ -251,3 +251,33 @@ def test_explicit_version_detection(test_workspace: Path):
     result = _run_tools(command, test_workspace)
     if result.returncode != 0:
         pytest.fail(f"Exit code: {result.returncode}, Output: {result.stdout}")
+
+
+def test_e2e_shard_count_three_manifest_matches_profile():
+    import importlib
+
+    e2e_shards = importlib.import_module("e2e_shards")
+
+    assignment = e2e_shards.get_e2e_shard_assignment(3)
+    counts = tuple(len(shard) for shard in assignment)
+    public_union = set().union(*assignment)
+    public_overlap = (
+        (assignment[0] & assignment[1])
+        | (assignment[0] & assignment[2])
+        | (assignment[1] & assignment[2])
+    )
+
+    assert e2e_shards.DEFAULT_E2E_SHARD_COUNT == 3
+    assert e2e_shards.supported_e2e_shard_counts() == (3,)
+    assert counts == (33, 35, 33)
+    assert len(public_union) == 101
+    assert public_overlap == set()
+
+
+def test_e2e_shard_count_requires_checked_in_assignment():
+    import importlib
+
+    e2e_shards = importlib.import_module("e2e_shards")
+
+    with pytest.raises(pytest.UsageError, match="Regenerate the shard assignment"):
+        e2e_shards.get_e2e_shard_assignment(2)


### PR DESCRIPTION
## Purpose

Reduce the CI test critical path by optimizing both the unit-test and E2E workflows.

For unit tests, independent model conversions now run in parallel with two `pytest-xdist` workers. Each worker uses an isolated temporary workspace for downloaded models, subprocess execution, conversion outputs, validation, and cleanup.

For E2E tests, Ubuntu retains full coverage of all 101 public cases using ten duration-balanced serial shards. Windows and macOS run a representative 30-case suite using two balanced shards per platform.

The representative suite covers the available CLI conversion routes while avoiding the cost of repeating the complete model matrix on every operating system. Tests that use the same physical model weights remain grouped where applicable, allowing weight reuse without introducing unsafe concurrent access to shared conversion resources.

## Specification

### Unit tests

- Added `pytest-xdist` as a development dependency.
- Added one session-scoped temporary workspace per pytest worker.
- Updated unit tests to:
  - download models into the current worker workspace
  - pass absolute model paths to the CLI
  - run conversion subprocesses from the worker workspace
  - validate NNArchive outputs from the corresponding workspace
- Updated cleanup fixtures to:
  - clean isolated workspace artifacts for unit tests
  - preserve the existing repository-root behavior for E2E tests
- Updated the unit-test CI workflow to use:
  - `-n 2`
  - `--dist load`
  - session-level weight reuse
- Preserved subprocess coverage collection by setting absolute coverage paths before starting conversions from the isolated workspaces.
- Updated the unit-test documentation with the parallel command.

### E2E tests

- Added checked-in deterministic E2E shard assignments generated from hosted CI timing data.
- Added two E2E suites:
  - `full`: all 101 public E2E cases
  - `representative`: 30 CLI conversion cases covering the available conversion routes
- Updated the GitHub Actions topology to run:
  - Ubuntu: the full suite using 10 shards
  - Windows: the representative suite using 2 shards
  - macOS: the representative suite using 2 shards
- The full 10-shard assignment contains:
  - 11 tests
  - 9 tests
  - 9 tests
  - 11 tests
  - 11 tests
  - 10 tests
  - 9 tests
  - 11 tests
  - 11 tests
  - 9 tests
- The representative 2-shard assignment contains:
  - 14 tests
  - 16 tests
- Kept execution serial inside each shard to avoid unsafe concurrent access to conversion outputs and shared tooling resources.
- Retained downloaded weights for the duration of each shard.
- Kept the three private E2E tests on shard 0 only for each operating system.
- Added explicit pytest options:
  - `--e2e-suite`
  - `--e2e-shard-index`
  - `--e2e-shard-count`
- The checked-in assignments currently support:
  - full suite with 3 or 10 shards
  - representative suite with 2 shards
- Unsupported suite and shard-count combinations fail with a clear message.

## Dependencies & Potential Impact

Adds:

- `pytest-xdist>=3.6.1`

The unit-test workflow deliberately uses two workers instead of `-n auto`.

In the controlled unit-test benchmark, mean peak aggregate process-tree RSS increased from approximately 1253 MiB during serial execution to 2321 MiB with two workers. This measurement may count some shared pages more than once, but it still supports using a fixed worker count to avoid unnecessary memory pressure on CI runners.

The isolated unit-test workspaces can contain the same model in more than one worker when both workers need it. The measured parallel runs contained 11 weight files representing 10 unique models, with `yolov8n` present in both workspaces.

E2E sharding increases the number of concurrent CI jobs, but the representative Windows and macOS suites substantially reduce total runner usage compared with running the full suite on every platform.

The latest hosted E2E run completed successfully in 33 minutes and 11 seconds:

- Ubuntu full suite:
  - 10 shards
  - approximately 15 to 17.5 minutes per shard
- Windows representative suite:
  - 2 shards
  - approximately 11 minutes per shard
- macOS representative suite:
  - 2 shards
  - approximately 10 to 11 minutes of execution per shard

The macOS jobs were queued and executed sequentially during this run, making macOS availability the critical path. Queueing may vary depending on shared GitHub Actions capacity. The tested 10/2/2 topology keeps the workflow simple while preserving full Ubuntu coverage and representative cross-platform coverage.

The coverage workflow also updated `media/coverage_badge.svg` automatically.

No product code or vendored submodules are modified.

## Testing & Validation

### Unit-test benchmark

A controlled ABBA comparison was run against the same 27-test conversion suite, using a fresh temporary workspace for every execution:

| Mode | Mean wall time |
| --- | ---: |
| Serial | 179.72 s |
| 2 workers | 97.07 s |

Results:

- 82.65 seconds saved on average
- 45.99% runtime reduction
- 1.85x speedup

### Final local validation

- All 32 current unit tests passed with two workers.
- All 9 telemetry tests passed.
- Pre-commit and `git diff --check` passed.
- All 104 E2E cases collect successfully.
- The full 10-shard public collections contain:
  - 11, 9, 9, 11, 11, 10, 9, 11, 11, and 9 tests
- The full shard union contains exactly 101 public tests.
- The representative 2-shard collections contain:
  - 14 tests
  - 16 tests
- The representative shard union contains exactly 30 public tests.
- The representative suite is a proper subset of the full suite.
- No public test appears in more than one shard within either assignment.
- Collection-drift validation detects both missing and stale assignments.
- Unsupported suite and shard-count combinations are rejected.
- Existing `--delete-weights-now` behavior remains compatible.
- Python 3.8 dependency resolution selects `pytest-xdist 3.6.1`.
- Repository isolation checks passed without leaving weights or conversion outputs in the working tree.

### Hosted E2E validation

The successful [10/2/2 hosted E2E run](https://github.com/luxonis/tools/actions/runs/29831173142) completed in 33 minutes and 11 seconds.

Observed execution times:

- Ubuntu full suite:
  - fastest shard: 14 minutes 59 seconds
  - slowest shard: 17 minutes 33 seconds
- Windows representative suite:
  - shard 0: 11 minutes 14 seconds
  - shard 1: 10 minutes 47 seconds
- macOS representative suite:
  - shard 0: 9 minutes 55 seconds
  - shard 1: 10 minutes 59 seconds

All 14 jobs completed successfully.

## Deployment Plan

No deployment required.

Rollout:

- review the successful hosted 10/2/2 E2E run
- confirm that private E2E tests run only on shard 0
- monitor runtime stability and macOS queueing in subsequent PR runs
- merge after review and successful checks

Rollback:

- revert the E2E sharding commits to restore one serial E2E job per operating system
- revert the unit-test parallelization changes to restore serial unit-test execution and per-test weight cleanup

Monitoring:

- unit-test runtime across the CI matrix
- E2E shard balance and total wall-clock runtime
- CI runner usage and queueing
- memory-related failures or instability
- model-download and DNS failures
- coverage generation
- reviewer feedback on shard configurability and workspace isolation

## AI Usage

Assisted-by: ChatGPT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Accelerated automated testing with parallel pytest runs and improved coverage reporting across environments.
  - Sharded end-to-end test execution (by suite and index) to reduce runtime while maintaining deterministic coverage.
  - Improved reliability by isolating temporary workspace artifacts per test and cleaning up generated outputs/weights more safely.
  - Expanded validation for explicit model versions, input sizes, encodings, and class names with workspace-scoped output checks.
- **Documentation**
  - Updated testing guidance with revised commands and clarified cleanup disk-space vs runtime trade-offs.
- **Chores**
  - Added `pytest-xdist` to support parallel test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->