### PR TITLE
Fix setuptools constraint for pip >= 26.2 via PIP_BUILD_CONSTRAINT

### DIFF
--- a/.github/workflows/end2end_tests.yaml
+++ b/.github/workflows/end2end_tests.yaml
@@ -45,6 +45,10 @@ jobs:
         CONSTRAINTS_FILE="$GITHUB_WORKSPACE/constraints.txt"
         echo "setuptools<82" > "$CONSTRAINTS_FILE"
         export PIP_CONSTRAINT="$CONSTRAINTS_FILE"
+        # pip >= 26.2 no longer applies PIP_CONSTRAINT to isolated build
+        # environments (needed for the mmcv sdist build, see
+        # https://github.com/open-mmlab/mmcv/issues/3325)
+        export PIP_BUILD_CONSTRAINT="$CONSTRAINTS_FILE"
         pip install -e .[dev]
 
     - name: Run full public tests
@@ -93,6 +97,10 @@ jobs:
         CONSTRAINTS_FILE="$GITHUB_WORKSPACE/constraints.txt"
         echo "setuptools<82" > "$CONSTRAINTS_FILE"
         export PIP_CONSTRAINT="$CONSTRAINTS_FILE"
+        # pip >= 26.2 no longer applies PIP_CONSTRAINT to isolated build
+        # environments (needed for the mmcv sdist build, see
+        # https://github.com/open-mmlab/mmcv/issues/3325)
+        export PIP_BUILD_CONSTRAINT="$CONSTRAINTS_FILE"
         pip install -e .[dev]
 
     - name: Run representative public tests

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -60,8 +60,12 @@ jobs:
       working-directory: ${{ inputs.tools_ref != '' && 'tools' || '' }}
       run: |
         CONSTRAINTS_FILE="$GITHUB_WORKSPACE/constraints.txt"
-        echo "setuptools<81" > "$CONSTRAINTS_FILE"
+        echo "setuptools<82" > "$CONSTRAINTS_FILE"
         export PIP_CONSTRAINT="$CONSTRAINTS_FILE"
+        # pip >= 26.2 no longer applies PIP_CONSTRAINT to isolated build
+        # environments (needed for the mmcv sdist build, see
+        # https://github.com/open-mmlab/mmcv/issues/3325)
+        export PIP_BUILD_CONSTRAINT="$CONSTRAINTS_FILE"
         pip install -e .[dev]
         pip install coverage-badge>=1.1.0 pytest-cov>=4.1.0
 
@@ -72,6 +76,9 @@ jobs:
       env:
         ML_REF: ${{ inputs.ml_ref }}
       run: |
+        CONSTRAINTS_FILE="$GITHUB_WORKSPACE/constraints.txt"
+        export PIP_CONSTRAINT="$CONSTRAINTS_FILE"
+        export PIP_BUILD_CONSTRAINT="$CONSTRAINTS_FILE"
         pip uninstall luxonis-ml -y
         pip install \
           "luxonis-ml[data,nn-archive,utils] @ git+https://github.com/luxonis/luxonis-ml.git@${ML_REF}" \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ cd tools
 
 ```bash
 # Install the package
-PIP_CONSTRAINT=constraints.txt pip install .
+# (PIP_BUILD_CONSTRAINT is required with pip >= 26.2, which no longer
+# applies PIP_CONSTRAINT to isolated build environments)
+PIP_CONSTRAINT=constraints.txt PIP_BUILD_CONSTRAINT=constraints.txt pip install .
 # Running the package
 tools yolov6nr4.pt --imgsz "416"
 ```


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

pip 26.2 enforces that PIP_CONSTRAINT no longer applies to isolated build environments, so the setuptools pin stopped protecting the mmcv sdist build (setup.py imports pkg_resources, removed in setuptools 82). Export PIP_BUILD_CONSTRAINT alongside PIP_CONSTRAINT and relax the unittests pin to the verified bound (<82, matching end2end and constraints.txt).


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to support pip’s isolated build environments and ensure compatible package builds.

* **Chores**
  * Improved automated test and installation workflows by applying consistent dependency constraints during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->